### PR TITLE
Regenerate allow unknown fields

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -414,7 +414,4 @@ model_update_wire_update_routing_details.go
 model_wealth_source.go
 model_wire_routing_details.go
 response.go
-test/api_crypto_deposits_test.go
-test/api_paxos_transfers_test.go
-test/api_settlement_test.go
 utils.go

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This SDK is generated from the OpenAPI spec found [here](https://docs.paxos.com/
 
 The CLI command to generate it was:
 ```sh
-openapi-generator generate -i paxos-v2.openapi.json -g go --package-name paxos --git-user-id avianlabs --git-repo-id paxos-go -t ./templates
+openapi-generator generate -i paxos-v2.openapi.json -g go --package-name paxos --git-user-id avianlabs --git-repo-id paxos-go --additional-properties=disallowAdditionalPropertiesIfNotPresent=false -t ./templates
 ```
 
 ### Templates

--- a/model_account.go
+++ b/model_account.go
@@ -44,7 +44,10 @@ type Account struct {
 	// The ID of the profile created for the account when `create_profile=true`. The [Profile](#tag/Profiles) type is `NORMAL`. The field is omitted when the account has no associated [Profile](#tag/Profiles).
 	ProfileId *string `json:"profile_id,omitempty"`
 	Type *AccountAccountType `json:"type,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Account Account
 
 // NewAccount instantiates a new Account object
 // This constructor will assign default values to properties that have it defined,
@@ -528,7 +531,45 @@ func (o Account) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Account) UnmarshalJSON(data []byte) (err error) {
+	varAccount := _Account{}
+
+	err = json.Unmarshal(data, &varAccount)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Account(varAccount)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "admin_disabled")
+		delete(additionalProperties, "user_disabled")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "members")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "summary_status")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "type")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAccount struct {

--- a/model_account_member.go
+++ b/model_account_member.go
@@ -24,7 +24,10 @@ type AccountMember struct {
 	Roles []AccountMemberAccountRoleType `json:"roles,omitempty"`
 	// Account member ID. Note: This field is auto-generated. Specifying an ID when creating an account member is a client error.
 	Id *string `json:"id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AccountMember AccountMember
 
 // NewAccountMember instantiates a new AccountMember object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,36 @@ func (o AccountMember) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AccountMember) UnmarshalJSON(data []byte) (err error) {
+	varAccountMember := _AccountMember{}
+
+	err = json.Unmarshal(data, &varAccountMember)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AccountMember(varAccountMember)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "roles")
+		delete(additionalProperties, "id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAccountMember struct {

--- a/model_add_account_members_request.go
+++ b/model_add_account_members_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type AddAccountMembersRequest struct {
 	AccountId string `json:"account_id"`
 	// A non-empty array of account members to be added.
 	Members []AccountMember `json:"members"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AddAccountMembersRequest AddAccountMembersRequest
@@ -108,6 +108,11 @@ func (o AddAccountMembersRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["account_id"] = o.AccountId
 	toSerialize["members"] = o.Members
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -136,15 +141,21 @@ func (o *AddAccountMembersRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varAddAccountMembersRequest := _AddAccountMembersRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAddAccountMembersRequest)
+	err = json.Unmarshal(data, &varAddAccountMembersRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AddAccountMembersRequest(varAddAccountMembersRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "members")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_add_account_members_response.go
+++ b/model_add_account_members_response.go
@@ -23,7 +23,10 @@ type AddAccountMembersResponse struct {
 	AccountId *string `json:"account_id,omitempty"`
 	// List of account members that were added to the account.
 	Members []AccountMember `json:"members,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AddAccountMembersResponse AddAccountMembersResponse
 
 // NewAddAccountMembersResponse instantiates a new AddAccountMembersResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,34 @@ func (o AddAccountMembersResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Members) {
 		toSerialize["members"] = o.Members
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AddAccountMembersResponse) UnmarshalJSON(data []byte) (err error) {
+	varAddAccountMembersResponse := _AddAccountMembersResponse{}
+
+	err = json.Unmarshal(data, &varAddAccountMembersResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AddAccountMembersResponse(varAddAccountMembersResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "members")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAddAccountMembersResponse struct {

--- a/model_add_institution_members_request.go
+++ b/model_add_institution_members_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type AddInstitutionMembersRequest struct {
 	InstitutionId string `json:"institution_id"`
 	// A non-empty array of institution members to be added.
 	Members []InstitutionMember `json:"members"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _AddInstitutionMembersRequest AddInstitutionMembersRequest
@@ -108,6 +108,11 @@ func (o AddInstitutionMembersRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["institution_id"] = o.InstitutionId
 	toSerialize["members"] = o.Members
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -136,15 +141,21 @@ func (o *AddInstitutionMembersRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varAddInstitutionMembersRequest := _AddInstitutionMembersRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varAddInstitutionMembersRequest)
+	err = json.Unmarshal(data, &varAddInstitutionMembersRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = AddInstitutionMembersRequest(varAddInstitutionMembersRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "institution_id")
+		delete(additionalProperties, "members")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_add_institution_members_response.go
+++ b/model_add_institution_members_response.go
@@ -23,7 +23,10 @@ type AddInstitutionMembersResponse struct {
 	InstitutionId *string `json:"institution_id,omitempty"`
 	// List of institution members that were added to the institution.
 	Members []InstitutionMember `json:"members,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AddInstitutionMembersResponse AddInstitutionMembersResponse
 
 // NewAddInstitutionMembersResponse instantiates a new AddInstitutionMembersResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,34 @@ func (o AddInstitutionMembersResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Members) {
 		toSerialize["members"] = o.Members
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AddInstitutionMembersResponse) UnmarshalJSON(data []byte) (err error) {
+	varAddInstitutionMembersResponse := _AddInstitutionMembersResponse{}
+
+	err = json.Unmarshal(data, &varAddInstitutionMembersResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AddInstitutionMembersResponse(varAddInstitutionMembersResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "institution_id")
+		delete(additionalProperties, "members")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAddInstitutionMembersResponse struct {

--- a/model_address_info.go
+++ b/model_address_info.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &AddressInfo{}
 type AddressInfo struct {
 	IndividualInfo *IndividualInfo `json:"individual_info,omitempty"`
 	InstitutionInfo *InstitutionInfo `json:"institution_info,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AddressInfo AddressInfo
 
 // NewAddressInfo instantiates a new AddressInfo object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o AddressInfo) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.InstitutionInfo) {
 		toSerialize["institution_info"] = o.InstitutionInfo
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AddressInfo) UnmarshalJSON(data []byte) (err error) {
+	varAddressInfo := _AddressInfo{}
+
+	err = json.Unmarshal(data, &varAddressInfo)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AddressInfo(varAddressInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "individual_info")
+		delete(additionalProperties, "institution_info")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAddressInfo struct {

--- a/model_api_http_body.go
+++ b/model_api_http_body.go
@@ -25,7 +25,10 @@ type ApiHttpBody struct {
 	Data *string `json:"data,omitempty"`
 	// Application specific response metadata. Must be set in the first response for streaming APIs.
 	Extensions []BufAny `json:"extensions,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ApiHttpBody ApiHttpBody
 
 // NewApiHttpBody instantiates a new ApiHttpBody object
 // This constructor will assign default values to properties that have it defined,
@@ -159,7 +162,35 @@ func (o ApiHttpBody) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Extensions) {
 		toSerialize["extensions"] = o.Extensions
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ApiHttpBody) UnmarshalJSON(data []byte) (err error) {
+	varApiHttpBody := _ApiHttpBody{}
+
+	err = json.Unmarshal(data, &varApiHttpBody)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ApiHttpBody(varApiHttpBody)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "content_type")
+		delete(additionalProperties, "data")
+		delete(additionalProperties, "extensions")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableApiHttpBody struct {

--- a/model_auto_conversion.go
+++ b/model_auto_conversion.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &AutoConversion{}
 type AutoConversion struct {
 	FromTransferId *string `json:"from_transfer_id,omitempty"`
 	ToTransferId *string `json:"to_transfer_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _AutoConversion AutoConversion
 
 // NewAutoConversion instantiates a new AutoConversion object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o AutoConversion) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ToTransferId) {
 		toSerialize["to_transfer_id"] = o.ToTransferId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *AutoConversion) UnmarshalJSON(data []byte) (err error) {
+	varAutoConversion := _AutoConversion{}
+
+	err = json.Unmarshal(data, &varAutoConversion)
+
+	if err != nil {
+		return err
+	}
+
+	*o = AutoConversion(varAutoConversion)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "from_transfer_id")
+		delete(additionalProperties, "to_transfer_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableAutoConversion struct {

--- a/model_beneficiary.go
+++ b/model_beneficiary.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &Beneficiary{}
 type Beneficiary struct {
 	PersonDetails *BeneficiaryPerson `json:"person_details,omitempty"`
 	InstitutionDetails *BeneficiaryInstitution `json:"institution_details,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Beneficiary Beneficiary
 
 // NewBeneficiary instantiates a new Beneficiary object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o Beneficiary) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.InstitutionDetails) {
 		toSerialize["institution_details"] = o.InstitutionDetails
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Beneficiary) UnmarshalJSON(data []byte) (err error) {
+	varBeneficiary := _Beneficiary{}
+
+	err = json.Unmarshal(data, &varBeneficiary)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Beneficiary(varBeneficiary)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "person_details")
+		delete(additionalProperties, "institution_details")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBeneficiary struct {

--- a/model_beneficiary_institution.go
+++ b/model_beneficiary_institution.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &BeneficiaryInstitution{}
 // BeneficiaryInstitution struct for BeneficiaryInstitution
 type BeneficiaryInstitution struct {
 	Name string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _BeneficiaryInstitution BeneficiaryInstitution
@@ -79,6 +79,11 @@ func (o BeneficiaryInstitution) MarshalJSON() ([]byte, error) {
 func (o BeneficiaryInstitution) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *BeneficiaryInstitution) UnmarshalJSON(data []byte) (err error) {
 
 	varBeneficiaryInstitution := _BeneficiaryInstitution{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varBeneficiaryInstitution)
+	err = json.Unmarshal(data, &varBeneficiaryInstitution)
 
 	if err != nil {
 		return err
 	}
 
 	*o = BeneficiaryInstitution(varBeneficiaryInstitution)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_beneficiary_person.go
+++ b/model_beneficiary_person.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &BeneficiaryPerson{}
 type BeneficiaryPerson struct {
 	FirstName *string `json:"first_name,omitempty"`
 	LastName *string `json:"last_name,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BeneficiaryPerson BeneficiaryPerson
 
 // NewBeneficiaryPerson instantiates a new BeneficiaryPerson object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o BeneficiaryPerson) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LastName) {
 		toSerialize["last_name"] = o.LastName
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BeneficiaryPerson) UnmarshalJSON(data []byte) (err error) {
+	varBeneficiaryPerson := _BeneficiaryPerson{}
+
+	err = json.Unmarshal(data, &varBeneficiaryPerson)
+
+	if err != nil {
+		return err
+	}
+
+	*o = BeneficiaryPerson(varBeneficiaryPerson)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "last_name")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBeneficiaryPerson struct {

--- a/model_book_level.go
+++ b/model_book_level.go
@@ -23,7 +23,10 @@ type BookLevel struct {
 	Price *string `json:"price,omitempty"`
 	// Amount of orders at pricing level.
 	Amount *string `json:"amount,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _BookLevel BookLevel
 
 // NewBookLevel instantiates a new BookLevel object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,34 @@ func (o BookLevel) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Amount) {
 		toSerialize["amount"] = o.Amount
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *BookLevel) UnmarshalJSON(data []byte) (err error) {
+	varBookLevel := _BookLevel{}
+
+	err = json.Unmarshal(data, &varBookLevel)
+
+	if err != nil {
+		return err
+	}
+
+	*o = BookLevel(varBookLevel)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "amount")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableBookLevel struct {

--- a/model_create_account_request.go
+++ b/model_create_account_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type CreateAccountRequest struct {
 	Account Account `json:"account"`
 	// Create a new profile for this account. Set to `true` to track user balances at the Profile level for this account. See also [Profiles](#tag/Profiles).
 	CreateProfile *bool `json:"create_profile,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateAccountRequest CreateAccountRequest
@@ -116,6 +116,11 @@ func (o CreateAccountRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CreateProfile) {
 		toSerialize["create_profile"] = o.CreateProfile
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -143,15 +148,21 @@ func (o *CreateAccountRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateAccountRequest := _CreateAccountRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateAccountRequest)
+	err = json.Unmarshal(data, &varCreateAccountRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateAccountRequest(varCreateAccountRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account")
+		delete(additionalProperties, "create_profile")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_crypto_withdrawal_fee_request.go
+++ b/model_create_crypto_withdrawal_fee_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -30,6 +29,7 @@ type CreateCryptoWithdrawalFeeRequest struct {
 	Amount *string `json:"amount,omitempty" validate:"regexp=^[0-9]*\\\\.?[0-9]+$"`
 	// Total amount to withdraw, including fees. Must be greater than `0`. Specify exactly one of `total ` or `amount`, otherwise an error is returned.
 	Total *string `json:"total,omitempty" validate:"regexp=^[0-9]*\\\\.?[0-9]+$"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateCryptoWithdrawalFeeRequest CreateCryptoWithdrawalFeeRequest
@@ -209,6 +209,11 @@ func (o CreateCryptoWithdrawalFeeRequest) ToMap() (map[string]interface{}, error
 	if !IsNil(o.Total) {
 		toSerialize["total"] = o.Total
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -238,15 +243,24 @@ func (o *CreateCryptoWithdrawalFeeRequest) UnmarshalJSON(data []byte) (err error
 
 	varCreateCryptoWithdrawalFeeRequest := _CreateCryptoWithdrawalFeeRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateCryptoWithdrawalFeeRequest)
+	err = json.Unmarshal(data, &varCreateCryptoWithdrawalFeeRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateCryptoWithdrawalFeeRequest(varCreateCryptoWithdrawalFeeRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "destination_address")
+		delete(additionalProperties, "crypto_network")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "total")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_crypto_withdrawal_request.go
+++ b/model_create_crypto_withdrawal_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -45,6 +44,7 @@ type CreateCryptoWithdrawalRequest struct {
 	// Total amount to withdraw, including fees. Specify exactly one of `amount` or `total`, otherwise an error is returned.
 	Total *string `json:"total,omitempty" validate:"regexp=^[0-9]*\\\\.?[0-9]+$"`
 	Beneficiary *Beneficiary `json:"beneficiary,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateCryptoWithdrawalRequest CreateCryptoWithdrawalRequest
@@ -495,6 +495,11 @@ func (o CreateCryptoWithdrawalRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Beneficiary) {
 		toSerialize["beneficiary"] = o.Beneficiary
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -525,15 +530,32 @@ func (o *CreateCryptoWithdrawalRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateCryptoWithdrawalRequest := _CreateCryptoWithdrawalRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateCryptoWithdrawalRequest)
+	err = json.Unmarshal(data, &varCreateCryptoWithdrawalRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateCryptoWithdrawalRequest(varCreateCryptoWithdrawalRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "destination_address")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "balance_asset")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "fee_id")
+		delete(additionalProperties, "crypto_network")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "total")
+		delete(additionalProperties, "beneficiary")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_deposit_address_request.go
+++ b/model_create_deposit_address_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type CreateDepositAddressRequest struct {
 	// The Account associated to the identity of the user that will be linked to the created address.
 	AccountId *string `json:"account_id,omitempty"`
 	ConversionTargetAsset *DepositAddressConversionTargetAsset `json:"conversion_target_asset,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateDepositAddressRequest CreateDepositAddressRequest
@@ -291,6 +291,11 @@ func (o CreateDepositAddressRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ConversionTargetAsset) {
 		toSerialize["conversion_target_asset"] = o.ConversionTargetAsset
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -319,15 +324,26 @@ func (o *CreateDepositAddressRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateDepositAddressRequest := _CreateDepositAddressRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateDepositAddressRequest)
+	err = json.Unmarshal(data, &varCreateDepositAddressRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateDepositAddressRequest(varCreateDepositAddressRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "crypto_network")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "conversion_target_asset")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_fiat_account_request.go
+++ b/model_create_fiat_account_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -31,6 +30,7 @@ type CreateFiatAccountRequest struct {
 	FiatNetworkInstructions FiatNetworkInstructions `json:"fiat_network_instructions"`
 	// Optional client-specified metadata. Up to 6 key/value pairs may be provided. Each key and value must be less than or equal to 100 characters.
 	Metadata *map[string]string `json:"metadata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateFiatAccountRequest CreateFiatAccountRequest
@@ -254,6 +254,11 @@ func (o CreateFiatAccountRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Metadata) {
 		toSerialize["metadata"] = o.Metadata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -282,15 +287,25 @@ func (o *CreateFiatAccountRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateFiatAccountRequest := _CreateFiatAccountRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateFiatAccountRequest)
+	err = json.Unmarshal(data, &varCreateFiatAccountRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateFiatAccountRequest(varCreateFiatAccountRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "fiat_account_owner")
+		delete(additionalProperties, "fiat_network_instructions")
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_fiat_deposit_instructions_request.go
+++ b/model_create_fiat_deposit_instructions_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type CreateFiatDepositInstructionsRequest struct {
 	RoutingNumberType *FiatWireAccountType `json:"routing_number_type,omitempty"`
 	// Optional client-specified metadata. Up to 6 key/value pairs may be provided. Each key and value must be less than or equal to 100 characters.
 	Metadata *map[string]string `json:"metadata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateFiatDepositInstructionsRequest CreateFiatDepositInstructionsRequest
@@ -291,6 +291,11 @@ func (o CreateFiatDepositInstructionsRequest) ToMap() (map[string]interface{}, e
 	if !IsNil(o.Metadata) {
 		toSerialize["metadata"] = o.Metadata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -319,15 +324,26 @@ func (o *CreateFiatDepositInstructionsRequest) UnmarshalJSON(data []byte) (err e
 
 	varCreateFiatDepositInstructionsRequest := _CreateFiatDepositInstructionsRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateFiatDepositInstructionsRequest)
+	err = json.Unmarshal(data, &varCreateFiatDepositInstructionsRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateFiatDepositInstructionsRequest(varCreateFiatDepositInstructionsRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "fiat_network")
+		delete(additionalProperties, "routing_number_type")
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_fiat_withdrawal_request.go
+++ b/model_create_fiat_withdrawal_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -41,6 +40,7 @@ type CreateFiatWithdrawalRequest struct {
 	Memo *string `json:"memo,omitempty" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]*$"`
 	// Total to withdraw, including fees. Specify exactly one of `amount` or `total`. When `total` is specified, Paxos initiates the withdrawal for `total` minus the fee.
 	Total *string `json:"total,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateFiatWithdrawalRequest CreateFiatWithdrawalRequest
@@ -395,6 +395,11 @@ func (o CreateFiatWithdrawalRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Total) {
 		toSerialize["total"] = o.Total
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -424,15 +429,29 @@ func (o *CreateFiatWithdrawalRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateFiatWithdrawalRequest := _CreateFiatWithdrawalRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateFiatWithdrawalRequest)
+	err = json.Unmarshal(data, &varCreateFiatWithdrawalRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateFiatWithdrawalRequest(varCreateFiatWithdrawalRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "fiat_account_id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "memo")
+		delete(additionalProperties, "total")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_identity_request.go
+++ b/model_create_identity_request.go
@@ -32,7 +32,10 @@ type CreateIdentityRequest struct {
 	CustomerDueDiligence *CustomerDueDiligence `json:"customer_due_diligence,omitempty"`
 	// Set to true to indicate that this identity is a merchant.
 	IsMerchant *bool `json:"is_merchant,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateIdentityRequest CreateIdentityRequest
 
 // NewCreateIdentityRequest instantiates a new CreateIdentityRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -376,7 +379,41 @@ func (o CreateIdentityRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.IsMerchant) {
 		toSerialize["is_merchant"] = o.IsMerchant
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateIdentityRequest) UnmarshalJSON(data []byte) (err error) {
+	varCreateIdentityRequest := _CreateIdentityRequest{}
+
+	err = json.Unmarshal(data, &varCreateIdentityRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateIdentityRequest(varCreateIdentityRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "person_details")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "institution_details")
+		delete(additionalProperties, "institution_members")
+		delete(additionalProperties, "tax_details")
+		delete(additionalProperties, "tax_details_not_required")
+		delete(additionalProperties, "customer_due_diligence")
+		delete(additionalProperties, "is_merchant")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateIdentityRequest struct {

--- a/model_create_internal_transfer_request.go
+++ b/model_create_internal_transfer_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -33,6 +32,7 @@ type CreateInternalTransferRequest struct {
 	Asset string `json:"asset"`
 	// Optional client-specified metadata. Up to 6 key/value pairs may be provided. Each key and value must be less than or equal to 100 characters.
 	Metadata *map[string]string `json:"metadata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateInternalTransferRequest CreateInternalTransferRequest
@@ -238,6 +238,11 @@ func (o CreateInternalTransferRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Metadata) {
 		toSerialize["metadata"] = o.Metadata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -268,15 +273,25 @@ func (o *CreateInternalTransferRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateInternalTransferRequest := _CreateInternalTransferRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateInternalTransferRequest)
+	err = json.Unmarshal(data, &varCreateInternalTransferRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateInternalTransferRequest(varCreateInternalTransferRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "from_profile_id")
+		delete(additionalProperties, "to_profile_id")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_obligation_request.go
+++ b/model_create_obligation_request.go
@@ -24,7 +24,10 @@ type CreateObligationRequest struct {
 	Asset *string `json:"asset,omitempty"`
 	// Amount of the asset which is obliged.
 	Amount *string `json:"amount,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateObligationRequest CreateObligationRequest
 
 // NewCreateObligationRequest instantiates a new CreateObligationRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -158,7 +161,35 @@ func (o CreateObligationRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Amount) {
 		toSerialize["amount"] = o.Amount
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateObligationRequest) UnmarshalJSON(data []byte) (err error) {
+	varCreateObligationRequest := _CreateObligationRequest{}
+
+	err = json.Unmarshal(data, &varCreateObligationRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateObligationRequest(varCreateObligationRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "direction")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "amount")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateObligationRequest struct {

--- a/model_create_order_request.go
+++ b/model_create_order_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -48,6 +47,7 @@ type CreateOrderRequest struct {
 	RecipientProfileId *string `json:"recipient_profile_id,omitempty"`
 	// The string field used to prevent matching against an opposite side order submitted by the same Crypto Brokerage customer. If this field is not submitted, an order that matches against another order submitted by the same customer will cancel the original resting order. Up to 36 characters are supported. This field requires additional permissions only available to certain accounts. Reach out to your Paxos Representative for more information.
 	SelfMatchPreventionId *string `json:"self_match_prevention_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateOrderRequest CreateOrderRequest
@@ -612,6 +612,11 @@ func (o CreateOrderRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SelfMatchPreventionId) {
 		toSerialize["self_match_prevention_id"] = o.SelfMatchPreventionId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -641,15 +646,35 @@ func (o *CreateOrderRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateOrderRequest := _CreateOrderRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateOrderRequest)
+	err = json.Unmarshal(data, &varCreateOrderRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateOrderRequest(varCreateOrderRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "side")
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "base_amount")
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "quote_amount")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "await_fill_millis")
+		delete(additionalProperties, "time_in_force")
+		delete(additionalProperties, "expiration_date")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "identity_account_id")
+		delete(additionalProperties, "stop_price")
+		delete(additionalProperties, "recipient_profile_id")
+		delete(additionalProperties, "self_match_prevention_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_paxos_transfer_request.go
+++ b/model_create_paxos_transfer_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -35,6 +34,7 @@ type CreatePaxosTransferRequest struct {
 	Metadata *map[string]string `json:"metadata,omitempty"`
 	// Optional client-specified metadata for the recipient side of the transaction. Up to 6 key/value pairs may be provided. Each key and value must be less than or equal to 100 characters.
 	RecipientMetadata *map[string]string `json:"recipient_metadata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreatePaxosTransferRequest CreatePaxosTransferRequest
@@ -275,6 +275,11 @@ func (o CreatePaxosTransferRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.RecipientMetadata) {
 		toSerialize["recipient_metadata"] = o.RecipientMetadata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -305,15 +310,26 @@ func (o *CreatePaxosTransferRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreatePaxosTransferRequest := _CreatePaxosTransferRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreatePaxosTransferRequest)
+	err = json.Unmarshal(data, &varCreatePaxosTransferRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreatePaxosTransferRequest(varCreatePaxosTransferRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "from_profile_id")
+		delete(additionalProperties, "to_profile_id")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "recipient_metadata")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_profile_request.go
+++ b/model_create_profile_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type CreateProfileRequest struct {
 	Nickname string `json:"nickname"`
 	// The description of the created profile.
 	Description *string `json:"description,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateProfileRequest CreateProfileRequest
@@ -117,6 +117,11 @@ func (o CreateProfileRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Description) {
 		toSerialize["description"] = o.Description
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -144,15 +149,21 @@ func (o *CreateProfileRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateProfileRequest := _CreateProfileRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateProfileRequest)
+	err = json.Unmarshal(data, &varCreateProfileRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateProfileRequest(varCreateProfileRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "nickname")
+		delete(additionalProperties, "description")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_quote_execution_request.go
+++ b/model_create_quote_execution_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -37,6 +36,7 @@ type CreateQuoteExecutionRequest struct {
 	AccountId *string `json:"account_id,omitempty"`
 	// The ID of the profile under which to deposit the funds.
 	RecipientProfileId *string `json:"recipient_profile_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateQuoteExecutionRequest CreateQuoteExecutionRequest
@@ -339,6 +339,11 @@ func (o CreateQuoteExecutionRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.RecipientProfileId) {
 		toSerialize["recipient_profile_id"] = o.RecipientProfileId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -366,15 +371,27 @@ func (o *CreateQuoteExecutionRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateQuoteExecutionRequest := _CreateQuoteExecutionRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateQuoteExecutionRequest)
+	err = json.Unmarshal(data, &varCreateQuoteExecutionRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateQuoteExecutionRequest(varCreateQuoteExecutionRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "quote_id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "base_amount")
+		delete(additionalProperties, "quote_amount")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "recipient_profile_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_sandbox_deposit_request.go
+++ b/model_create_sandbox_deposit_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type CreateSandboxDepositRequest struct {
 	// The amount to deposit.
 	Amount string `json:"amount" validate:"regexp=^[0-9]*\\\\.?[0-9]+$"`
 	CryptoNetwork *CryptoNetwork `json:"crypto_network,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateSandboxDepositRequest CreateSandboxDepositRequest
@@ -144,6 +144,11 @@ func (o CreateSandboxDepositRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CryptoNetwork) {
 		toSerialize["crypto_network"] = o.CryptoNetwork
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -172,15 +177,22 @@ func (o *CreateSandboxDepositRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varCreateSandboxDepositRequest := _CreateSandboxDepositRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateSandboxDepositRequest)
+	err = json.Unmarshal(data, &varCreateSandboxDepositRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateSandboxDepositRequest(varCreateSandboxDepositRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "crypto_network")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_sandbox_deposit_response.go
+++ b/model_create_sandbox_deposit_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &CreateSandboxDepositResponse{}
 type CreateSandboxDepositResponse struct {
 	// The UUID of the customer activity created for the deposit.
 	ActivityId *string `json:"activity_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateSandboxDepositResponse CreateSandboxDepositResponse
 
 // NewCreateSandboxDepositResponse instantiates a new CreateSandboxDepositResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o CreateSandboxDepositResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ActivityId) {
 		toSerialize["activity_id"] = o.ActivityId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateSandboxDepositResponse) UnmarshalJSON(data []byte) (err error) {
+	varCreateSandboxDepositResponse := _CreateSandboxDepositResponse{}
+
+	err = json.Unmarshal(data, &varCreateSandboxDepositResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateSandboxDepositResponse(varCreateSandboxDepositResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "activity_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateSandboxDepositResponse struct {

--- a/model_create_stablecoin_conversion_request.go
+++ b/model_create_stablecoin_conversion_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -39,6 +38,7 @@ type CreateStablecoinConversionRequest struct {
 	Metadata *map[string]string `json:"metadata,omitempty"`
 	// For directed settlement, the receiving side `profile_id`.
 	RecipientProfileId *string `json:"recipient_profile_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CreateStablecoinConversionRequest CreateStablecoinConversionRequest
@@ -349,6 +349,11 @@ func (o CreateStablecoinConversionRequest) ToMap() (map[string]interface{}, erro
 	if !IsNil(o.RecipientProfileId) {
 		toSerialize["recipient_profile_id"] = o.RecipientProfileId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -379,15 +384,28 @@ func (o *CreateStablecoinConversionRequest) UnmarshalJSON(data []byte) (err erro
 
 	varCreateStablecoinConversionRequest := _CreateStablecoinConversionRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCreateStablecoinConversionRequest)
+	err = json.Unmarshal(data, &varCreateStablecoinConversionRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CreateStablecoinConversionRequest(varCreateStablecoinConversionRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "source_asset")
+		delete(additionalProperties, "target_asset")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "recipient_profile_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_create_transaction_request.go
+++ b/model_create_transaction_request.go
@@ -32,7 +32,10 @@ type CreateTransactionRequest struct {
 	TargetProfileId *string `json:"target_profile_id,omitempty"`
 	// The obligations (representing one-way asset movements) to be settled atomically.
 	Legs []CreateObligationRequest `json:"legs,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CreateTransactionRequest CreateTransactionRequest
 
 // NewCreateTransactionRequest instantiates a new CreateTransactionRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -271,7 +274,38 @@ func (o CreateTransactionRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Legs) {
 		toSerialize["legs"] = o.Legs
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CreateTransactionRequest) UnmarshalJSON(data []byte) (err error) {
+	varCreateTransactionRequest := _CreateTransactionRequest{}
+
+	err = json.Unmarshal(data, &varCreateTransactionRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CreateTransactionRequest(varCreateTransactionRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "settlement_window_start")
+		delete(additionalProperties, "settlement_window_end")
+		delete(additionalProperties, "source_profile_id")
+		delete(additionalProperties, "target_profile_id")
+		delete(additionalProperties, "legs")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCreateTransactionRequest struct {

--- a/model_crypto_withdrawal_fee.go
+++ b/model_crypto_withdrawal_fee.go
@@ -13,7 +13,6 @@ package paxos
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -37,6 +36,7 @@ type CryptoWithdrawalFee struct {
 	Amount *string `json:"amount,omitempty" validate:"regexp=^[0-9]*\\\\.?[0-9]+$"`
 	// Total amount to withdraw, including fees. Specify exactly one of `amount` or `total`, otherwise an error is returned.
 	Total *string `json:"total,omitempty" validate:"regexp=^[0-9]*\\\\.?[0-9]+$"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _CryptoWithdrawalFee CryptoWithdrawalFee
@@ -294,6 +294,11 @@ func (o CryptoWithdrawalFee) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Total) {
 		toSerialize["total"] = o.Total
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -326,15 +331,27 @@ func (o *CryptoWithdrawalFee) UnmarshalJSON(data []byte) (err error) {
 
 	varCryptoWithdrawalFee := _CryptoWithdrawalFee{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varCryptoWithdrawalFee)
+	err = json.Unmarshal(data, &varCryptoWithdrawalFee)
 
 	if err != nil {
 		return err
 	}
 
 	*o = CryptoWithdrawalFee(varCryptoWithdrawalFee)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "fee")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "expires_at")
+		delete(additionalProperties, "destination_address")
+		delete(additionalProperties, "crypto_network")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "total")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_customer_due_diligence.go
+++ b/model_customer_due_diligence.go
@@ -41,7 +41,10 @@ type CustomerDueDiligence struct {
 	MerchantFundingSource *MerchantFundingSourceFundingSource `json:"merchant_funding_source,omitempty"`
 	// Regions where the customer base is located.
 	CustomerRegions []CustomerRegion `json:"customer_regions,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _CustomerDueDiligence CustomerDueDiligence
 
 // NewCustomerDueDiligence instantiates a new CustomerDueDiligence object
 // This constructor will assign default values to properties that have it defined,
@@ -630,7 +633,48 @@ func (o CustomerDueDiligence) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CustomerRegions) {
 		toSerialize["customer_regions"] = o.CustomerRegions
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *CustomerDueDiligence) UnmarshalJSON(data []byte) (err error) {
+	varCustomerDueDiligence := _CustomerDueDiligence{}
+
+	err = json.Unmarshal(data, &varCustomerDueDiligence)
+
+	if err != nil {
+		return err
+	}
+
+	*o = CustomerDueDiligence(varCustomerDueDiligence)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "aliases")
+		delete(additionalProperties, "estimated_net_worth")
+		delete(additionalProperties, "estimated_yearly_income")
+		delete(additionalProperties, "expected_transfer_value")
+		delete(additionalProperties, "source_of_wealth")
+		delete(additionalProperties, "source_of_funds")
+		delete(additionalProperties, "purpose_of_account")
+		delete(additionalProperties, "employment_status")
+		delete(additionalProperties, "employment_industry_sector")
+		delete(additionalProperties, "industry_sector")
+		delete(additionalProperties, "has_underlying_trust_structure")
+		delete(additionalProperties, "has_nominee_shareholders")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "is_publicly_traded")
+		delete(additionalProperties, "merchant_funding_source")
+		delete(additionalProperties, "customer_regions")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableCustomerDueDiligence struct {

--- a/model_deposit_address.go
+++ b/model_deposit_address.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -41,6 +40,7 @@ type DepositAddress struct {
 	ConversionTargetAsset DepositAddressConversionTargetAsset `json:"conversion_target_asset"`
 	// List of networks compatible with the created address. Any of these networks can be used to deposit to the address.
 	CompatibleCryptoNetworks []CryptoNetwork `json:"compatible_crypto_networks,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _DepositAddress DepositAddress
@@ -403,6 +403,11 @@ func (o DepositAddress) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.CompatibleCryptoNetworks) {
 		toSerialize["compatible_crypto_networks"] = o.CompatibleCryptoNetworks
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -435,15 +440,30 @@ func (o *DepositAddress) UnmarshalJSON(data []byte) (err error) {
 
 	varDepositAddress := _DepositAddress{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varDepositAddress)
+	err = json.Unmarshal(data, &varDepositAddress)
 
 	if err != nil {
 		return err
 	}
 
 	*o = DepositAddress(varDepositAddress)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "customer_id")
+		delete(additionalProperties, "crypto_network")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "conversion_target_asset")
+		delete(additionalProperties, "compatible_crypto_networks")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_document_description.go
+++ b/model_document_description.go
@@ -25,7 +25,10 @@ type DocumentDescription struct {
 	DocumentTypes []DocumentType `json:"document_types,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	ArchivedAt *time.Time `json:"archived_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DocumentDescription DocumentDescription
 
 // NewDocumentDescription instantiates a new DocumentDescription object
 // This constructor will assign default values to properties that have it defined,
@@ -229,7 +232,37 @@ func (o DocumentDescription) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ArchivedAt) {
 		toSerialize["archived_at"] = o.ArchivedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DocumentDescription) UnmarshalJSON(data []byte) (err error) {
+	varDocumentDescription := _DocumentDescription{}
+
+	err = json.Unmarshal(data, &varDocumentDescription)
+
+	if err != nil {
+		return err
+	}
+
+	*o = DocumentDescription(varDocumentDescription)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "file_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "document_types")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "archived_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDocumentDescription struct {

--- a/model_document_upload_request.go
+++ b/model_document_upload_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -25,6 +24,7 @@ type DocumentUploadRequest struct {
 	Name string `json:"name"`
 	// A list of document types contained within the uploaded file.
 	DocumentTypes []DocumentType `json:"document_types,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _DocumentUploadRequest DocumentUploadRequest
@@ -117,6 +117,11 @@ func (o DocumentUploadRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.DocumentTypes) {
 		toSerialize["document_types"] = o.DocumentTypes
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -144,15 +149,21 @@ func (o *DocumentUploadRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varDocumentUploadRequest := _DocumentUploadRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varDocumentUploadRequest)
+	err = json.Unmarshal(data, &varDocumentUploadRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = DocumentUploadRequest(varDocumentUploadRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "document_types")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_document_upload_response.go
+++ b/model_document_upload_response.go
@@ -25,7 +25,10 @@ type DocumentUploadResponse struct {
 	Name *string `json:"name,omitempty"`
 	// The URI where we expect the file to be uploaded into.
 	UploadUrl *string `json:"upload_url,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _DocumentUploadResponse DocumentUploadResponse
 
 // NewDocumentUploadResponse instantiates a new DocumentUploadResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -159,7 +162,35 @@ func (o DocumentUploadResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.UploadUrl) {
 		toSerialize["upload_url"] = o.UploadUrl
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *DocumentUploadResponse) UnmarshalJSON(data []byte) (err error) {
+	varDocumentUploadResponse := _DocumentUploadResponse{}
+
+	err = json.Unmarshal(data, &varDocumentUploadResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = DocumentUploadResponse(varDocumentUploadResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "file_id")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "upload_url")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableDocumentUploadResponse struct {

--- a/model_exchange_stats.go
+++ b/model_exchange_stats.go
@@ -29,7 +29,10 @@ type ExchangeStats struct {
 	// Volume-Weighted Average Price over Time Period.
 	VolumeWeightedAveragePrice *string `json:"volume_weighted_average_price,omitempty"`
 	Range *TimestampRange `json:"range,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ExchangeStats ExchangeStats
 
 // NewExchangeStats instantiates a new ExchangeStats object
 // This constructor will assign default values to properties that have it defined,
@@ -268,7 +271,38 @@ func (o ExchangeStats) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Range) {
 		toSerialize["range"] = o.Range
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ExchangeStats) UnmarshalJSON(data []byte) (err error) {
+	varExchangeStats := _ExchangeStats{}
+
+	err = json.Unmarshal(data, &varExchangeStats)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ExchangeStats(varExchangeStats)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "high")
+		delete(additionalProperties, "low")
+		delete(additionalProperties, "open")
+		delete(additionalProperties, "volume")
+		delete(additionalProperties, "volume_weighted_average_price")
+		delete(additionalProperties, "range")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableExchangeStats struct {

--- a/model_execution.go
+++ b/model_execution.go
@@ -43,7 +43,10 @@ type Execution struct {
 	AccountId *string `json:"account_id,omitempty"`
 	// The total asset traded (asset amount multiplied by price paid).
 	GrossTradeAmount *string `json:"gross_trade_amount,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Execution Execution
 
 // NewExecution instantiates a new Execution object
 // This constructor will assign default values to properties that have it defined,
@@ -527,7 +530,45 @@ func (o Execution) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.GrossTradeAmount) {
 		toSerialize["gross_trade_amount"] = o.GrossTradeAmount
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Execution) UnmarshalJSON(data []byte) (err error) {
+	varExecution := _Execution{}
+
+	err = json.Unmarshal(data, &varExecution)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Execution(varExecution)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "execution_id")
+		delete(additionalProperties, "order_id")
+		delete(additionalProperties, "executed_at")
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "side")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "commission")
+		delete(additionalProperties, "commission_asset")
+		delete(additionalProperties, "rebate")
+		delete(additionalProperties, "rebate_asset")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "gross_trade_amount")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableExecution struct {

--- a/model_fiat_account.go
+++ b/model_fiat_account.go
@@ -37,7 +37,10 @@ type FiatAccount struct {
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	// The time at which this FiatAccount record was most recently updated.
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FiatAccount FiatAccount
 
 // NewFiatAccount instantiates a new FiatAccount object
 // This constructor will assign default values to properties that have it defined,
@@ -416,7 +419,42 @@ func (o FiatAccount) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.UpdatedAt) {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FiatAccount) UnmarshalJSON(data []byte) (err error) {
+	varFiatAccount := _FiatAccount{}
+
+	err = json.Unmarshal(data, &varFiatAccount)
+
+	if err != nil {
+		return err
+	}
+
+	*o = FiatAccount(varFiatAccount)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "fiat_account_owner")
+		delete(additionalProperties, "fiat_network_instructions")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFiatAccount struct {

--- a/model_fiat_account_owner.go
+++ b/model_fiat_account_owner.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &FiatAccountOwner{}
 type FiatAccountOwner struct {
 	PersonDetails *FiatAccountOwnerPersonDetails `json:"person_details,omitempty"`
 	InstitutionDetails *FiatAccountOwnerInstitutionDetails `json:"institution_details,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FiatAccountOwner FiatAccountOwner
 
 // NewFiatAccountOwner instantiates a new FiatAccountOwner object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o FiatAccountOwner) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.InstitutionDetails) {
 		toSerialize["institution_details"] = o.InstitutionDetails
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FiatAccountOwner) UnmarshalJSON(data []byte) (err error) {
+	varFiatAccountOwner := _FiatAccountOwner{}
+
+	err = json.Unmarshal(data, &varFiatAccountOwner)
+
+	if err != nil {
+		return err
+	}
+
+	*o = FiatAccountOwner(varFiatAccountOwner)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "person_details")
+		delete(additionalProperties, "institution_details")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFiatAccountOwner struct {

--- a/model_fiat_account_owner_institution_details.go
+++ b/model_fiat_account_owner_institution_details.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &FiatAccountOwnerInstitutionDetails{}
 // FiatAccountOwnerInstitutionDetails struct for FiatAccountOwnerInstitutionDetails
 type FiatAccountOwnerInstitutionDetails struct {
 	Name string `json:"name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FiatAccountOwnerInstitutionDetails FiatAccountOwnerInstitutionDetails
@@ -79,6 +79,11 @@ func (o FiatAccountOwnerInstitutionDetails) MarshalJSON() ([]byte, error) {
 func (o FiatAccountOwnerInstitutionDetails) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *FiatAccountOwnerInstitutionDetails) UnmarshalJSON(data []byte) (err err
 
 	varFiatAccountOwnerInstitutionDetails := _FiatAccountOwnerInstitutionDetails{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFiatAccountOwnerInstitutionDetails)
+	err = json.Unmarshal(data, &varFiatAccountOwnerInstitutionDetails)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FiatAccountOwnerInstitutionDetails(varFiatAccountOwnerInstitutionDetails)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_fiat_account_owner_person_details.go
+++ b/model_fiat_account_owner_person_details.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &FiatAccountOwnerPersonDetails{}
 type FiatAccountOwnerPersonDetails struct {
 	FirstName string `json:"first_name"`
 	LastName string `json:"last_name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FiatAccountOwnerPersonDetails FiatAccountOwnerPersonDetails
@@ -106,6 +106,11 @@ func (o FiatAccountOwnerPersonDetails) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["first_name"] = o.FirstName
 	toSerialize["last_name"] = o.LastName
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *FiatAccountOwnerPersonDetails) UnmarshalJSON(data []byte) (err error) {
 
 	varFiatAccountOwnerPersonDetails := _FiatAccountOwnerPersonDetails{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFiatAccountOwnerPersonDetails)
+	err = json.Unmarshal(data, &varFiatAccountOwnerPersonDetails)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FiatAccountOwnerPersonDetails(varFiatAccountOwnerPersonDetails)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "last_name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_fiat_deposit_instructions.go
+++ b/model_fiat_deposit_instructions.go
@@ -13,7 +13,6 @@ package paxos
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -41,6 +40,7 @@ type FiatDepositInstructions struct {
 	Metadata *map[string]string `json:"metadata,omitempty"`
 	// The time at which these instructions were created.
 	CreatedAt time.Time `json:"created_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FiatDepositInstructions FiatDepositInstructions
@@ -394,6 +394,11 @@ func (o FiatDepositInstructions) ToMap() (map[string]interface{}, error) {
 		toSerialize["metadata"] = o.Metadata
 	}
 	toSerialize["created_at"] = o.CreatedAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -427,15 +432,30 @@ func (o *FiatDepositInstructions) UnmarshalJSON(data []byte) (err error) {
 
 	varFiatDepositInstructions := _FiatDepositInstructions{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFiatDepositInstructions)
+	err = json.Unmarshal(data, &varFiatDepositInstructions)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FiatDepositInstructions(varFiatDepositInstructions)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "memo_id")
+		delete(additionalProperties, "fiat_network_instructions")
+		delete(additionalProperties, "fiat_account_owner")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "created_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_fiat_network_instructions.go
+++ b/model_fiat_network_instructions.go
@@ -23,7 +23,10 @@ type FiatNetworkInstructions struct {
 	Cbit *FiatNetworkInstructionsCbit `json:"cbit,omitempty"`
 	DbsAct *FiatNetworkInstructionsDbsAct `json:"dbs_act,omitempty"`
 	Cubix *FiatNetworkInstructionsCubix `json:"cubix,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _FiatNetworkInstructions FiatNetworkInstructions
 
 // NewFiatNetworkInstructions instantiates a new FiatNetworkInstructions object
 // This constructor will assign default values to properties that have it defined,
@@ -192,7 +195,36 @@ func (o FiatNetworkInstructions) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Cubix) {
 		toSerialize["cubix"] = o.Cubix
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *FiatNetworkInstructions) UnmarshalJSON(data []byte) (err error) {
+	varFiatNetworkInstructions := _FiatNetworkInstructions{}
+
+	err = json.Unmarshal(data, &varFiatNetworkInstructions)
+
+	if err != nil {
+		return err
+	}
+
+	*o = FiatNetworkInstructions(varFiatNetworkInstructions)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "wire")
+		delete(additionalProperties, "cbit")
+		delete(additionalProperties, "dbs_act")
+		delete(additionalProperties, "cubix")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableFiatNetworkInstructions struct {

--- a/model_fiat_network_instructions_cbit.go
+++ b/model_fiat_network_instructions_cbit.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &FiatNetworkInstructionsCbit{}
 type FiatNetworkInstructionsCbit struct {
 	// The wallet address of the CBIT account.
 	WalletAddress string `json:"wallet_address"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FiatNetworkInstructionsCbit FiatNetworkInstructionsCbit
@@ -80,6 +80,11 @@ func (o FiatNetworkInstructionsCbit) MarshalJSON() ([]byte, error) {
 func (o FiatNetworkInstructionsCbit) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["wallet_address"] = o.WalletAddress
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *FiatNetworkInstructionsCbit) UnmarshalJSON(data []byte) (err error) {
 
 	varFiatNetworkInstructionsCbit := _FiatNetworkInstructionsCbit{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFiatNetworkInstructionsCbit)
+	err = json.Unmarshal(data, &varFiatNetworkInstructionsCbit)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FiatNetworkInstructionsCbit(varFiatNetworkInstructionsCbit)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "wallet_address")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_fiat_network_instructions_cubix.go
+++ b/model_fiat_network_instructions_cubix.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &FiatNetworkInstructionsCubix{}
 type FiatNetworkInstructionsCubix struct {
 	// The uuid account id of the CUBIX account.
 	AccountId string `json:"account_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FiatNetworkInstructionsCubix FiatNetworkInstructionsCubix
@@ -80,6 +80,11 @@ func (o FiatNetworkInstructionsCubix) MarshalJSON() ([]byte, error) {
 func (o FiatNetworkInstructionsCubix) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["account_id"] = o.AccountId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *FiatNetworkInstructionsCubix) UnmarshalJSON(data []byte) (err error) {
 
 	varFiatNetworkInstructionsCubix := _FiatNetworkInstructionsCubix{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFiatNetworkInstructionsCubix)
+	err = json.Unmarshal(data, &varFiatNetworkInstructionsCubix)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FiatNetworkInstructionsCubix(varFiatNetworkInstructionsCubix)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_fiat_network_instructions_dbs_act.go
+++ b/model_fiat_network_instructions_dbs_act.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &FiatNetworkInstructionsDbsAct{}
 type FiatNetworkInstructionsDbsAct struct {
 	// The account number of the DBS account.
 	AccountNumber string `json:"account_number"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FiatNetworkInstructionsDbsAct FiatNetworkInstructionsDbsAct
@@ -80,6 +80,11 @@ func (o FiatNetworkInstructionsDbsAct) MarshalJSON() ([]byte, error) {
 func (o FiatNetworkInstructionsDbsAct) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["account_number"] = o.AccountNumber
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *FiatNetworkInstructionsDbsAct) UnmarshalJSON(data []byte) (err error) {
 
 	varFiatNetworkInstructionsDbsAct := _FiatNetworkInstructionsDbsAct{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFiatNetworkInstructionsDbsAct)
+	err = json.Unmarshal(data, &varFiatNetworkInstructionsDbsAct)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FiatNetworkInstructionsDbsAct(varFiatNetworkInstructionsDbsAct)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account_number")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_fiat_network_instructions_wire.go
+++ b/model_fiat_network_instructions_wire.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type FiatNetworkInstructionsWire struct {
 	FiatAccountOwnerAddress MailingAddress `json:"fiat_account_owner_address"`
 	RoutingDetails WireRoutingDetails `json:"routing_details"`
 	IntermediaryRoutingDetails *WireRoutingDetails `json:"intermediary_routing_details,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _FiatNetworkInstructionsWire FiatNetworkInstructionsWire
@@ -170,6 +170,11 @@ func (o FiatNetworkInstructionsWire) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.IntermediaryRoutingDetails) {
 		toSerialize["intermediary_routing_details"] = o.IntermediaryRoutingDetails
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -199,15 +204,23 @@ func (o *FiatNetworkInstructionsWire) UnmarshalJSON(data []byte) (err error) {
 
 	varFiatNetworkInstructionsWire := _FiatNetworkInstructionsWire{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varFiatNetworkInstructionsWire)
+	err = json.Unmarshal(data, &varFiatNetworkInstructionsWire)
 
 	if err != nil {
 		return err
 	}
 
 	*o = FiatNetworkInstructionsWire(varFiatNetworkInstructionsWire)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account_number")
+		delete(additionalProperties, "fiat_account_owner_address")
+		delete(additionalProperties, "routing_details")
+		delete(additionalProperties, "intermediary_routing_details")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_get_order_book_response.go
+++ b/model_get_order_book_response.go
@@ -24,7 +24,10 @@ type GetOrderBookResponse struct {
 	// All Bids.
 	Bids []BookLevel `json:"bids,omitempty"`
 	Market *Market `json:"market,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _GetOrderBookResponse GetOrderBookResponse
 
 // NewGetOrderBookResponse instantiates a new GetOrderBookResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -158,7 +161,35 @@ func (o GetOrderBookResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Market) {
 		toSerialize["market"] = o.Market
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *GetOrderBookResponse) UnmarshalJSON(data []byte) (err error) {
+	varGetOrderBookResponse := _GetOrderBookResponse{}
+
+	err = json.Unmarshal(data, &varGetOrderBookResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = GetOrderBookResponse(varGetOrderBookResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "asks")
+		delete(additionalProperties, "bids")
+		delete(additionalProperties, "market")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableGetOrderBookResponse struct {

--- a/model_historical_price.go
+++ b/model_historical_price.go
@@ -24,7 +24,10 @@ type HistoricalPrice struct {
 	AveragePrice *string `json:"average_price,omitempty"`
 	// Timestamp at the beginning of an increment.
 	Timestamp *time.Time `json:"timestamp,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _HistoricalPrice HistoricalPrice
 
 // NewHistoricalPrice instantiates a new HistoricalPrice object
 // This constructor will assign default values to properties that have it defined,
@@ -123,7 +126,34 @@ func (o HistoricalPrice) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Timestamp) {
 		toSerialize["timestamp"] = o.Timestamp
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *HistoricalPrice) UnmarshalJSON(data []byte) (err error) {
+	varHistoricalPrice := _HistoricalPrice{}
+
+	err = json.Unmarshal(data, &varHistoricalPrice)
+
+	if err != nil {
+		return err
+	}
+
+	*o = HistoricalPrice(varHistoricalPrice)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "average_price")
+		delete(additionalProperties, "timestamp")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableHistoricalPrice struct {

--- a/model_identity.go
+++ b/model_identity.go
@@ -13,7 +13,6 @@ package paxos
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -43,6 +42,7 @@ type Identity struct {
 	CustomerDueDiligence *CustomerDueDiligence `json:"customer_due_diligence,omitempty"`
 	// True if the identity is a merchant.
 	IsMerchant *bool `json:"is_merchant,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Identity Identity
@@ -660,6 +660,11 @@ func (o Identity) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.IsMerchant) {
 		toSerialize["is_merchant"] = o.IsMerchant
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -687,15 +692,36 @@ func (o *Identity) UnmarshalJSON(data []byte) (err error) {
 
 	varIdentity := _Identity{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varIdentity)
+	err = json.Unmarshal(data, &varIdentity)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Identity(varIdentity)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "summary_status")
+		delete(additionalProperties, "user_disabled")
+		delete(additionalProperties, "admin_disabled")
+		delete(additionalProperties, "person_details")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "institution_details")
+		delete(additionalProperties, "institution_members")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "tax_details")
+		delete(additionalProperties, "tax_details_not_required")
+		delete(additionalProperties, "summary_tin_verification_status")
+		delete(additionalProperties, "customer_due_diligence")
+		delete(additionalProperties, "is_merchant")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_identity_mailing_address.go
+++ b/model_identity_mailing_address.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -28,6 +27,7 @@ type IdentityMailingAddress struct {
 	City string `json:"city" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]+$"`
 	Province string `json:"province" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]+$"`
 	ZipCode *string `json:"zip_code,omitempty" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]+$"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _IdentityMailingAddress IdentityMailingAddress
@@ -233,6 +233,11 @@ func (o IdentityMailingAddress) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ZipCode) {
 		toSerialize["zip_code"] = o.ZipCode
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -263,15 +268,25 @@ func (o *IdentityMailingAddress) UnmarshalJSON(data []byte) (err error) {
 
 	varIdentityMailingAddress := _IdentityMailingAddress{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varIdentityMailingAddress)
+	err = json.Unmarshal(data, &varIdentityMailingAddress)
 
 	if err != nil {
 		return err
 	}
 
 	*o = IdentityMailingAddress(varIdentityMailingAddress)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "address1")
+		delete(additionalProperties, "address2")
+		delete(additionalProperties, "city")
+		delete(additionalProperties, "province")
+		delete(additionalProperties, "zip_code")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_individual_info.go
+++ b/model_individual_info.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &IndividualInfo{}
 type IndividualInfo struct {
 	FirstName string `json:"first_name"`
 	LastName string `json:"last_name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _IndividualInfo IndividualInfo
@@ -106,6 +106,11 @@ func (o IndividualInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["first_name"] = o.FirstName
 	toSerialize["last_name"] = o.LastName
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -134,15 +139,21 @@ func (o *IndividualInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varIndividualInfo := _IndividualInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varIndividualInfo)
+	err = json.Unmarshal(data, &varIndividualInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = IndividualInfo(varIndividualInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "last_name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_initiate_sandbox_fiat_deposit_request.go
+++ b/model_initiate_sandbox_fiat_deposit_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -29,6 +28,7 @@ type InitiateSandboxFiatDepositRequest struct {
 	MemoId string `json:"memo_id"`
 	FiatNetworkInstructions FiatNetworkInstructions `json:"fiat_network_instructions"`
 	FiatAccountOwner *FiatAccountOwner `json:"fiat_account_owner,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _InitiateSandboxFiatDepositRequest InitiateSandboxFiatDepositRequest
@@ -199,6 +199,11 @@ func (o InitiateSandboxFiatDepositRequest) ToMap() (map[string]interface{}, erro
 	if !IsNil(o.FiatAccountOwner) {
 		toSerialize["fiat_account_owner"] = o.FiatAccountOwner
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -229,15 +234,24 @@ func (o *InitiateSandboxFiatDepositRequest) UnmarshalJSON(data []byte) (err erro
 
 	varInitiateSandboxFiatDepositRequest := _InitiateSandboxFiatDepositRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varInitiateSandboxFiatDepositRequest)
+	err = json.Unmarshal(data, &varInitiateSandboxFiatDepositRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = InitiateSandboxFiatDepositRequest(varInitiateSandboxFiatDepositRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "memo_id")
+		delete(additionalProperties, "fiat_network_instructions")
+		delete(additionalProperties, "fiat_account_owner")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_institution_details.go
+++ b/model_institution_details.go
@@ -46,7 +46,10 @@ type InstitutionDetails struct {
 	AdditionalScreeningStatus *IdentityStatus `json:"additional_screening_status,omitempty"`
 	DoingBusinessAs *string `json:"doing_business_as,omitempty"`
 	BusinessDescription *string `json:"business_description,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InstitutionDetails InstitutionDetails
 
 // NewInstitutionDetails instantiates a new InstitutionDetails object
 // This constructor will assign default values to properties that have it defined,
@@ -915,7 +918,56 @@ func (o InstitutionDetails) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.BusinessDescription) {
 		toSerialize["business_description"] = o.BusinessDescription
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InstitutionDetails) UnmarshalJSON(data []byte) (err error) {
+	varInstitutionDetails := _InstitutionDetails{}
+
+	err = json.Unmarshal(data, &varInstitutionDetails)
+
+	if err != nil {
+		return err
+	}
+
+	*o = InstitutionDetails(varInstitutionDetails)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "sanctions_verification_status")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "business_address")
+		delete(additionalProperties, "phone_number")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "institution_type")
+		delete(additionalProperties, "institution_sub_type")
+		delete(additionalProperties, "cip_id")
+		delete(additionalProperties, "cip_id_type")
+		delete(additionalProperties, "cip_id_country")
+		delete(additionalProperties, "govt_registration_date")
+		delete(additionalProperties, "incorporation_address")
+		delete(additionalProperties, "regulation_status")
+		delete(additionalProperties, "trading_type")
+		delete(additionalProperties, "listed_exchange")
+		delete(additionalProperties, "ticker_symbol")
+		delete(additionalProperties, "parent_institution_name")
+		delete(additionalProperties, "regulator_name")
+		delete(additionalProperties, "regulator_jurisdiction")
+		delete(additionalProperties, "regulator_register_number")
+		delete(additionalProperties, "document_verification_status")
+		delete(additionalProperties, "additional_screening_status")
+		delete(additionalProperties, "doing_business_as")
+		delete(additionalProperties, "business_description")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInstitutionDetails struct {

--- a/model_institution_info.go
+++ b/model_institution_info.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &InstitutionInfo{}
 // InstitutionInfo struct for InstitutionInfo
 type InstitutionInfo struct {
 	InstitutionName string `json:"institution_name"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _InstitutionInfo InstitutionInfo
@@ -79,6 +79,11 @@ func (o InstitutionInfo) MarshalJSON() ([]byte, error) {
 func (o InstitutionInfo) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["institution_name"] = o.InstitutionName
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *InstitutionInfo) UnmarshalJSON(data []byte) (err error) {
 
 	varInstitutionInfo := _InstitutionInfo{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varInstitutionInfo)
+	err = json.Unmarshal(data, &varInstitutionInfo)
 
 	if err != nil {
 		return err
 	}
 
 	*o = InstitutionInfo(varInstitutionInfo)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "institution_name")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_institution_member.go
+++ b/model_institution_member.go
@@ -28,7 +28,10 @@ type InstitutionMember struct {
 	SummaryStatus *IdentityStatus `json:"summary_status,omitempty"`
 	// Institution member ID. Note: This field is auto-generated. Specifying an ID when creating an institution member is a client error.
 	Id *string `json:"id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _InstitutionMember InstitutionMember
 
 // NewInstitutionMember instantiates a new InstitutionMember object
 // This constructor will assign default values to properties that have it defined,
@@ -302,7 +305,39 @@ func (o InstitutionMember) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Id) {
 		toSerialize["id"] = o.Id
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *InstitutionMember) UnmarshalJSON(data []byte) (err error) {
+	varInstitutionMember := _InstitutionMember{}
+
+	err = json.Unmarshal(data, &varInstitutionMember)
+
+	if err != nil {
+		return err
+	}
+
+	*o = InstitutionMember(varInstitutionMember)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "roles")
+		delete(additionalProperties, "ownership")
+		delete(additionalProperties, "position")
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "summary_status")
+		delete(additionalProperties, "id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableInstitutionMember struct {

--- a/model_list_accounts_response.go
+++ b/model_list_accounts_response.go
@@ -23,7 +23,10 @@ type ListAccountsResponse struct {
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
 	// The result list of accounts.
 	Items []Account `json:"items,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListAccountsResponse ListAccountsResponse
 
 // NewListAccountsResponse instantiates a new ListAccountsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,34 @@ func (o ListAccountsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Items) {
 		toSerialize["items"] = o.Items
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListAccountsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListAccountsResponse := _ListAccountsResponse{}
+
+	err = json.Unmarshal(data, &varListAccountsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListAccountsResponse(varListAccountsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "next_page_cursor")
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListAccountsResponse struct {

--- a/model_list_deposit_addresses_response.go
+++ b/model_list_deposit_addresses_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListDepositAddressesResponse{}
 type ListDepositAddressesResponse struct {
 	Items []DepositAddress `json:"items,omitempty"`
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListDepositAddressesResponse ListDepositAddressesResponse
 
 // NewListDepositAddressesResponse instantiates a new ListDepositAddressesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ListDepositAddressesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListDepositAddressesResponse) UnmarshalJSON(data []byte) (err error) {
+	varListDepositAddressesResponse := _ListDepositAddressesResponse{}
+
+	err = json.Unmarshal(data, &varListDepositAddressesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListDepositAddressesResponse(varListDepositAddressesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListDepositAddressesResponse struct {

--- a/model_list_executions_response.go
+++ b/model_list_executions_response.go
@@ -22,7 +22,10 @@ type ListExecutionsResponse struct {
 	Items []Execution `json:"items,omitempty"`
 	// Cursor token required for fetching the next page.
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListExecutionsResponse ListExecutionsResponse
 
 // NewListExecutionsResponse instantiates a new ListExecutionsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o ListExecutionsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListExecutionsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListExecutionsResponse := _ListExecutionsResponse{}
+
+	err = json.Unmarshal(data, &varListExecutionsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListExecutionsResponse(varListExecutionsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListExecutionsResponse struct {

--- a/model_list_fiat_accounts_response.go
+++ b/model_list_fiat_accounts_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListFiatAccountsResponse{}
 type ListFiatAccountsResponse struct {
 	Items []FiatAccount `json:"items,omitempty"`
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListFiatAccountsResponse ListFiatAccountsResponse
 
 // NewListFiatAccountsResponse instantiates a new ListFiatAccountsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ListFiatAccountsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListFiatAccountsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListFiatAccountsResponse := _ListFiatAccountsResponse{}
+
+	err = json.Unmarshal(data, &varListFiatAccountsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListFiatAccountsResponse(varListFiatAccountsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListFiatAccountsResponse struct {

--- a/model_list_fiat_deposit_instructions_response.go
+++ b/model_list_fiat_deposit_instructions_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListFiatDepositInstructionsResponse{}
 type ListFiatDepositInstructionsResponse struct {
 	Items []FiatDepositInstructions `json:"items,omitempty"`
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListFiatDepositInstructionsResponse ListFiatDepositInstructionsResponse
 
 // NewListFiatDepositInstructionsResponse instantiates a new ListFiatDepositInstructionsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ListFiatDepositInstructionsResponse) ToMap() (map[string]interface{}, er
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListFiatDepositInstructionsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListFiatDepositInstructionsResponse := _ListFiatDepositInstructionsResponse{}
+
+	err = json.Unmarshal(data, &varListFiatDepositInstructionsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListFiatDepositInstructionsResponse(varListFiatDepositInstructionsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListFiatDepositInstructionsResponse struct {

--- a/model_list_historical_prices_response.go
+++ b/model_list_historical_prices_response.go
@@ -22,7 +22,10 @@ type ListHistoricalPricesResponse struct {
 	TotalCount *int32 `json:"total_count,omitempty"`
 	// List of historical prices.
 	Items []HistoricalPrice `json:"items,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListHistoricalPricesResponse ListHistoricalPricesResponse
 
 // NewListHistoricalPricesResponse instantiates a new ListHistoricalPricesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o ListHistoricalPricesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Items) {
 		toSerialize["items"] = o.Items
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListHistoricalPricesResponse) UnmarshalJSON(data []byte) (err error) {
+	varListHistoricalPricesResponse := _ListHistoricalPricesResponse{}
+
+	err = json.Unmarshal(data, &varListHistoricalPricesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListHistoricalPricesResponse(varListHistoricalPricesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListHistoricalPricesResponse struct {

--- a/model_list_identities_response.go
+++ b/model_list_identities_response.go
@@ -23,7 +23,10 @@ type ListIdentitiesResponse struct {
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
 	// The result list of identities.
 	Items []Identity `json:"items,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListIdentitiesResponse ListIdentitiesResponse
 
 // NewListIdentitiesResponse instantiates a new ListIdentitiesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,34 @@ func (o ListIdentitiesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Items) {
 		toSerialize["items"] = o.Items
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListIdentitiesResponse) UnmarshalJSON(data []byte) (err error) {
+	varListIdentitiesResponse := _ListIdentitiesResponse{}
+
+	err = json.Unmarshal(data, &varListIdentitiesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListIdentitiesResponse(varListIdentitiesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "next_page_cursor")
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListIdentitiesResponse struct {

--- a/model_list_identity_documents_response.go
+++ b/model_list_identity_documents_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListIdentityDocumentsResponse{}
 type ListIdentityDocumentsResponse struct {
 	Documents []DocumentDescription `json:"documents,omitempty"`
 	PendingDocuments []DocumentType `json:"pending_documents,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListIdentityDocumentsResponse ListIdentityDocumentsResponse
 
 // NewListIdentityDocumentsResponse instantiates a new ListIdentityDocumentsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ListIdentityDocumentsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.PendingDocuments) {
 		toSerialize["pending_documents"] = o.PendingDocuments
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListIdentityDocumentsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListIdentityDocumentsResponse := _ListIdentityDocumentsResponse{}
+
+	err = json.Unmarshal(data, &varListIdentityDocumentsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListIdentityDocumentsResponse(varListIdentityDocumentsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "documents")
+		delete(additionalProperties, "pending_documents")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListIdentityDocumentsResponse struct {

--- a/model_list_markets_response.go
+++ b/model_list_markets_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ListMarketsResponse{}
 // ListMarketsResponse struct for ListMarketsResponse
 type ListMarketsResponse struct {
 	Markets []MarketDetails `json:"markets,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListMarketsResponse ListMarketsResponse
 
 // NewListMarketsResponse instantiates a new ListMarketsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ListMarketsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Markets) {
 		toSerialize["markets"] = o.Markets
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListMarketsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListMarketsResponse := _ListMarketsResponse{}
+
+	err = json.Unmarshal(data, &varListMarketsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListMarketsResponse(varListMarketsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "markets")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListMarketsResponse struct {

--- a/model_list_orders_response.go
+++ b/model_list_orders_response.go
@@ -22,7 +22,10 @@ type ListOrdersResponse struct {
 	Items []Order `json:"items,omitempty"`
 	// Cursor token required for fetching the next page.
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListOrdersResponse ListOrdersResponse
 
 // NewListOrdersResponse instantiates a new ListOrdersResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o ListOrdersResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListOrdersResponse) UnmarshalJSON(data []byte) (err error) {
+	varListOrdersResponse := _ListOrdersResponse{}
+
+	err = json.Unmarshal(data, &varListOrdersResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListOrdersResponse(varListOrdersResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListOrdersResponse struct {

--- a/model_list_prices_response.go
+++ b/model_list_prices_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ListPricesResponse{}
 // ListPricesResponse struct for ListPricesResponse
 type ListPricesResponse struct {
 	Items []Pricing `json:"items,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListPricesResponse ListPricesResponse
 
 // NewListPricesResponse instantiates a new ListPricesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ListPricesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Items) {
 		toSerialize["items"] = o.Items
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListPricesResponse) UnmarshalJSON(data []byte) (err error) {
+	varListPricesResponse := _ListPricesResponse{}
+
+	err = json.Unmarshal(data, &varListPricesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListPricesResponse(varListPricesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListPricesResponse struct {

--- a/model_list_profile_balances_response.go
+++ b/model_list_profile_balances_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ListProfileBalancesResponse{}
 // ListProfileBalancesResponse struct for ListProfileBalancesResponse
 type ListProfileBalancesResponse struct {
 	Items []ProfileBalance `json:"items,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListProfileBalancesResponse ListProfileBalancesResponse
 
 // NewListProfileBalancesResponse instantiates a new ListProfileBalancesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ListProfileBalancesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Items) {
 		toSerialize["items"] = o.Items
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListProfileBalancesResponse) UnmarshalJSON(data []byte) (err error) {
+	varListProfileBalancesResponse := _ListProfileBalancesResponse{}
+
+	err = json.Unmarshal(data, &varListProfileBalancesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListProfileBalancesResponse(varListProfileBalancesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListProfileBalancesResponse struct {

--- a/model_list_profiles_response.go
+++ b/model_list_profiles_response.go
@@ -22,7 +22,10 @@ type ListProfilesResponse struct {
 	Items []Profile `json:"items,omitempty"`
 	// Cursor token required for fetching the next page.
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListProfilesResponse ListProfilesResponse
 
 // NewListProfilesResponse instantiates a new ListProfilesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o ListProfilesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListProfilesResponse) UnmarshalJSON(data []byte) (err error) {
+	varListProfilesResponse := _ListProfilesResponse{}
+
+	err = json.Unmarshal(data, &varListProfilesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListProfilesResponse(varListProfilesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListProfilesResponse struct {

--- a/model_list_quote_executions_response.go
+++ b/model_list_quote_executions_response.go
@@ -23,7 +23,10 @@ type ListQuoteExecutionsResponse struct {
 	Items []QuoteExecution `json:"items,omitempty"`
 	// Cursor token required for fetching the next page.
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListQuoteExecutionsResponse ListQuoteExecutionsResponse
 
 // NewListQuoteExecutionsResponse instantiates a new ListQuoteExecutionsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,35 @@ func (o ListQuoteExecutionsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListQuoteExecutionsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListQuoteExecutionsResponse := _ListQuoteExecutionsResponse{}
+
+	err = json.Unmarshal(data, &varListQuoteExecutionsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListQuoteExecutionsResponse(varListQuoteExecutionsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "total_count")
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListQuoteExecutionsResponse struct {

--- a/model_list_quotes_response.go
+++ b/model_list_quotes_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ListQuotesResponse{}
 // ListQuotesResponse struct for ListQuotesResponse
 type ListQuotesResponse struct {
 	Items []Quote `json:"items,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListQuotesResponse ListQuotesResponse
 
 // NewListQuotesResponse instantiates a new ListQuotesResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ListQuotesResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Items) {
 		toSerialize["items"] = o.Items
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListQuotesResponse) UnmarshalJSON(data []byte) (err error) {
+	varListQuotesResponse := _ListQuotesResponse{}
+
+	err = json.Unmarshal(data, &varListQuotesResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListQuotesResponse(varListQuotesResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListQuotesResponse struct {

--- a/model_list_recent_executions_response.go
+++ b/model_list_recent_executions_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListRecentExecutionsResponse{}
 type ListRecentExecutionsResponse struct {
 	// Recent Executions.
 	Items []RecentExecution `json:"items,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListRecentExecutionsResponse ListRecentExecutionsResponse
 
 // NewListRecentExecutionsResponse instantiates a new ListRecentExecutionsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o ListRecentExecutionsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Items) {
 		toSerialize["items"] = o.Items
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListRecentExecutionsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListRecentExecutionsResponse := _ListRecentExecutionsResponse{}
+
+	err = json.Unmarshal(data, &varListRecentExecutionsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListRecentExecutionsResponse(varListRecentExecutionsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListRecentExecutionsResponse struct {

--- a/model_list_stablecoin_conversions_response.go
+++ b/model_list_stablecoin_conversions_response.go
@@ -22,7 +22,10 @@ type ListStablecoinConversionsResponse struct {
 	Items []StablecoinConversion `json:"items,omitempty"`
 	// Cursor token required for fetching the next page.
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListStablecoinConversionsResponse ListStablecoinConversionsResponse
 
 // NewListStablecoinConversionsResponse instantiates a new ListStablecoinConversionsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o ListStablecoinConversionsResponse) ToMap() (map[string]interface{}, erro
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListStablecoinConversionsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListStablecoinConversionsResponse := _ListStablecoinConversionsResponse{}
+
+	err = json.Unmarshal(data, &varListStablecoinConversionsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListStablecoinConversionsResponse(varListStablecoinConversionsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListStablecoinConversionsResponse struct {

--- a/model_list_tax_form_revisions_response.go
+++ b/model_list_tax_form_revisions_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ListTaxFormRevisionsResponse{}
 // ListTaxFormRevisionsResponse struct for ListTaxFormRevisionsResponse
 type ListTaxFormRevisionsResponse struct {
 	TaxFormUrls []TaxFormURL `json:"tax_form_urls,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListTaxFormRevisionsResponse ListTaxFormRevisionsResponse
 
 // NewListTaxFormRevisionsResponse instantiates a new ListTaxFormRevisionsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ListTaxFormRevisionsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.TaxFormUrls) {
 		toSerialize["tax_form_urls"] = o.TaxFormUrls
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListTaxFormRevisionsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListTaxFormRevisionsResponse := _ListTaxFormRevisionsResponse{}
+
+	err = json.Unmarshal(data, &varListTaxFormRevisionsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListTaxFormRevisionsResponse(varListTaxFormRevisionsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "tax_form_urls")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListTaxFormRevisionsResponse struct {

--- a/model_list_tax_forms_response.go
+++ b/model_list_tax_forms_response.go
@@ -23,7 +23,10 @@ type ListTaxFormsResponse struct {
 	TaxFormUrls []TaxFormURL `json:"tax_form_urls,omitempty"`
 	// Cursor token required for fetching the next page.
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListTaxFormsResponse ListTaxFormsResponse
 
 // NewListTaxFormsResponse instantiates a new ListTaxFormsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -122,7 +125,34 @@ func (o ListTaxFormsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListTaxFormsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListTaxFormsResponse := _ListTaxFormsResponse{}
+
+	err = json.Unmarshal(data, &varListTaxFormsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListTaxFormsResponse(varListTaxFormsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "tax_form_urls")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListTaxFormsResponse struct {

--- a/model_list_tickers_response.go
+++ b/model_list_tickers_response.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ListTickersResponse{}
 // ListTickersResponse struct for ListTickersResponse
 type ListTickersResponse struct {
 	Tickers []TickerRecord `json:"tickers,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListTickersResponse ListTickersResponse
 
 // NewListTickersResponse instantiates a new ListTickersResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o ListTickersResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Tickers) {
 		toSerialize["tickers"] = o.Tickers
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListTickersResponse) UnmarshalJSON(data []byte) (err error) {
+	varListTickersResponse := _ListTickersResponse{}
+
+	err = json.Unmarshal(data, &varListTickersResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListTickersResponse(varListTickersResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "tickers")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListTickersResponse struct {

--- a/model_list_transactions_response.go
+++ b/model_list_transactions_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListTransactionsResponse{}
 type ListTransactionsResponse struct {
 	Items []Transaction `json:"items,omitempty"`
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListTransactionsResponse ListTransactionsResponse
 
 // NewListTransactionsResponse instantiates a new ListTransactionsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ListTransactionsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListTransactionsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListTransactionsResponse := _ListTransactionsResponse{}
+
+	err = json.Unmarshal(data, &varListTransactionsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListTransactionsResponse(varListTransactionsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListTransactionsResponse struct {

--- a/model_list_transfer_limits_response.go
+++ b/model_list_transfer_limits_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListTransferLimitsResponse{}
 type ListTransferLimitsResponse struct {
 	Items []TransferLimit `json:"items,omitempty"`
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListTransferLimitsResponse ListTransferLimitsResponse
 
 // NewListTransferLimitsResponse instantiates a new ListTransferLimitsResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ListTransferLimitsResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListTransferLimitsResponse) UnmarshalJSON(data []byte) (err error) {
+	varListTransferLimitsResponse := _ListTransferLimitsResponse{}
+
+	err = json.Unmarshal(data, &varListTransferLimitsResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListTransferLimitsResponse(varListTransferLimitsResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListTransferLimitsResponse struct {

--- a/model_list_transfers_response.go
+++ b/model_list_transfers_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &ListTransfersResponse{}
 type ListTransfersResponse struct {
 	Items []Transfer `json:"items,omitempty"`
 	NextPageCursor *string `json:"next_page_cursor,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _ListTransfersResponse ListTransfersResponse
 
 // NewListTransfersResponse instantiates a new ListTransfersResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o ListTransfersResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.NextPageCursor) {
 		toSerialize["next_page_cursor"] = o.NextPageCursor
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *ListTransfersResponse) UnmarshalJSON(data []byte) (err error) {
+	varListTransfersResponse := _ListTransfersResponse{}
+
+	err = json.Unmarshal(data, &varListTransfersResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = ListTransfersResponse(varListTransfersResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "items")
+		delete(additionalProperties, "next_page_cursor")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableListTransfersResponse struct {

--- a/model_mailing_address.go
+++ b/model_mailing_address.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type MailingAddress struct {
 	City *string `json:"city,omitempty" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]+$"`
 	Province *string `json:"province,omitempty" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]+$"`
 	ZipCode *string `json:"zip_code,omitempty" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]+$"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _MailingAddress MailingAddress
@@ -259,6 +259,11 @@ func (o MailingAddress) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ZipCode) {
 		toSerialize["zip_code"] = o.ZipCode
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -286,15 +291,25 @@ func (o *MailingAddress) UnmarshalJSON(data []byte) (err error) {
 
 	varMailingAddress := _MailingAddress{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varMailingAddress)
+	err = json.Unmarshal(data, &varMailingAddress)
 
 	if err != nil {
 		return err
 	}
 
 	*o = MailingAddress(varMailingAddress)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "country")
+		delete(additionalProperties, "address1")
+		delete(additionalProperties, "address2")
+		delete(additionalProperties, "city")
+		delete(additionalProperties, "province")
+		delete(additionalProperties, "zip_code")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_market_details.go
+++ b/model_market_details.go
@@ -24,7 +24,10 @@ type MarketDetails struct {
 	// Quote asset. Fiat Only (USD, EUR, SGD).
 	QuoteAsset *string `json:"quote_asset,omitempty"`
 	TickRate *string `json:"tick_rate,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _MarketDetails MarketDetails
 
 // NewMarketDetails instantiates a new MarketDetails object
 // This constructor will assign default values to properties that have it defined,
@@ -193,7 +196,36 @@ func (o MarketDetails) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.TickRate) {
 		toSerialize["tick_rate"] = o.TickRate
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *MarketDetails) UnmarshalJSON(data []byte) (err error) {
+	varMarketDetails := _MarketDetails{}
+
+	err = json.Unmarshal(data, &varMarketDetails)
+
+	if err != nil {
+		return err
+	}
+
+	*o = MarketDetails(varMarketDetails)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "base_asset")
+		delete(additionalProperties, "quote_asset")
+		delete(additionalProperties, "tick_rate")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableMarketDetails struct {

--- a/model_order.go
+++ b/model_order.go
@@ -58,7 +58,10 @@ type Order struct {
 	RecipientProfileId *string `json:"recipient_profile_id,omitempty"`
 	// Returns `true` when a stop order has been triggered.
 	IsTriggered *bool `json:"is_triggered,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Order Order
 
 // NewOrder instantiates a new Order object
 // This constructor will assign default values to properties that have it defined,
@@ -857,7 +860,54 @@ func (o Order) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.IsTriggered) {
 		toSerialize["is_triggered"] = o.IsTriggered
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Order) UnmarshalJSON(data []byte) (err error) {
+	varOrder := _Order{}
+
+	err = json.Unmarshal(data, &varOrder)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Order(varOrder)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "side")
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "base_amount")
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "quote_amount")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "modified_at")
+		delete(additionalProperties, "amount_filled")
+		delete(additionalProperties, "volume_weighted_average_price")
+		delete(additionalProperties, "time_in_force")
+		delete(additionalProperties, "expiration_date")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "identity_account_id")
+		delete(additionalProperties, "stop_price")
+		delete(additionalProperties, "recipient_profile_id")
+		delete(additionalProperties, "is_triggered")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableOrder struct {

--- a/model_pagination.go
+++ b/model_pagination.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &Pagination{}
 type Pagination struct {
 	Limit *int32 `json:"limit,omitempty"`
 	Offset *int32 `json:"offset,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Pagination Pagination
 
 // NewPagination instantiates a new Pagination object
 // This constructor will assign default values to properties that have it defined,
@@ -120,7 +123,34 @@ func (o Pagination) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Offset) {
 		toSerialize["offset"] = o.Offset
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Pagination) UnmarshalJSON(data []byte) (err error) {
+	varPagination := _Pagination{}
+
+	err = json.Unmarshal(data, &varPagination)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Pagination(varPagination)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "limit")
+		delete(additionalProperties, "offset")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePagination struct {

--- a/model_person_details.go
+++ b/model_person_details.go
@@ -52,7 +52,10 @@ type PersonDetails struct {
 	PassthroughVerificationStatus *IdentityStatus `json:"passthrough_verification_status,omitempty"`
 	// List of verification fields used by the external verifier to validate the individual's identity.
 	PassthroughVerificationFields []PassthroughVerificationField `json:"passthrough_verification_fields,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _PersonDetails PersonDetails
 
 // NewPersonDetails instantiates a new PersonDetails object
 // This constructor will assign default values to properties that have it defined,
@@ -991,7 +994,58 @@ func (o PersonDetails) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.PassthroughVerificationFields) {
 		toSerialize["passthrough_verification_fields"] = o.PassthroughVerificationFields
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *PersonDetails) UnmarshalJSON(data []byte) (err error) {
+	varPersonDetails := _PersonDetails{}
+
+	err = json.Unmarshal(data, &varPersonDetails)
+
+	if err != nil {
+		return err
+	}
+
+	*o = PersonDetails(varPersonDetails)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id_verification_status")
+		delete(additionalProperties, "sanctions_verification_status")
+		delete(additionalProperties, "first_name")
+		delete(additionalProperties, "last_name")
+		delete(additionalProperties, "date_of_birth")
+		delete(additionalProperties, "govt_id")
+		delete(additionalProperties, "address")
+		delete(additionalProperties, "phone_number")
+		delete(additionalProperties, "email")
+		delete(additionalProperties, "nationality")
+		delete(additionalProperties, "verifier_id")
+		delete(additionalProperties, "verifier_type")
+		delete(additionalProperties, "id_verification_url")
+		delete(additionalProperties, "passthrough_verifier_type")
+		delete(additionalProperties, "passthrough_verified_at")
+		delete(additionalProperties, "govt_id_type")
+		delete(additionalProperties, "cip_id")
+		delete(additionalProperties, "cip_id_type")
+		delete(additionalProperties, "cip_id_country")
+		delete(additionalProperties, "additional_screening_status")
+		delete(additionalProperties, "profession")
+		delete(additionalProperties, "middle_name")
+		delete(additionalProperties, "country_of_birth")
+		delete(additionalProperties, "passthrough_verification_id")
+		delete(additionalProperties, "passthrough_verification_status")
+		delete(additionalProperties, "passthrough_verification_fields")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePersonDetails struct {

--- a/model_pricing.go
+++ b/model_pricing.go
@@ -27,7 +27,10 @@ type Pricing struct {
 	YesterdayPrice *string `json:"yesterday_price,omitempty"`
 	// The time when the price was generated. RFC3339 format, like `2023-01-03T18:27:40.294528Z`.
 	SnapshotAt *time.Time `json:"snapshot_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Pricing Pricing
 
 // NewPricing instantiates a new Pricing object
 // This constructor will assign default values to properties that have it defined,
@@ -196,7 +199,36 @@ func (o Pricing) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SnapshotAt) {
 		toSerialize["snapshot_at"] = o.SnapshotAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Pricing) UnmarshalJSON(data []byte) (err error) {
+	varPricing := _Pricing{}
+
+	err = json.Unmarshal(data, &varPricing)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Pricing(varPricing)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "current_price")
+		delete(additionalProperties, "yesterday_price")
+		delete(additionalProperties, "snapshot_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullablePricing struct {

--- a/model_problem.go
+++ b/model_problem.go
@@ -29,7 +29,10 @@ type Problem struct {
 	Detail *string `json:"detail,omitempty"`
 	// Additional structured metadata about the error. 
 	Meta map[string]interface{} `json:"meta,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _Problem Problem
 
 // NewProblem instantiates a new Problem object
 // This constructor will assign default values to properties that have it defined,
@@ -237,7 +240,37 @@ func (o Problem) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Meta) {
 		toSerialize["meta"] = o.Meta
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *Problem) UnmarshalJSON(data []byte) (err error) {
+	varProblem := _Problem{}
+
+	err = json.Unmarshal(data, &varProblem)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Problem(varProblem)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "title")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "detail")
+		delete(additionalProperties, "meta")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableProblem struct {

--- a/model_profile.go
+++ b/model_profile.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -26,6 +25,7 @@ type Profile struct {
 	Type ProfileType `json:"type"`
 	Description *string `json:"description,omitempty"`
 	AccountId *string `json:"account_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Profile Profile
@@ -205,6 +205,11 @@ func (o Profile) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AccountId) {
 		toSerialize["account_id"] = o.AccountId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -234,15 +239,24 @@ func (o *Profile) UnmarshalJSON(data []byte) (err error) {
 
 	varProfile := _Profile{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varProfile)
+	err = json.Unmarshal(data, &varProfile)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Profile(varProfile)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "nickname")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "description")
+		delete(additionalProperties, "account_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_profile_balance.go
+++ b/model_profile_balance.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type ProfileBalance struct {
 	Available string `json:"available"`
 	// The asset amount committed to pending orders.
 	Trading string `json:"trading"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _ProfileBalance ProfileBalance
@@ -136,6 +136,11 @@ func (o ProfileBalance) ToMap() (map[string]interface{}, error) {
 	toSerialize["asset"] = o.Asset
 	toSerialize["available"] = o.Available
 	toSerialize["trading"] = o.Trading
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -165,15 +170,22 @@ func (o *ProfileBalance) UnmarshalJSON(data []byte) (err error) {
 
 	varProfileBalance := _ProfileBalance{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varProfileBalance)
+	err = json.Unmarshal(data, &varProfileBalance)
 
 	if err != nil {
 		return err
 	}
 
 	*o = ProfileBalance(varProfileBalance)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "available")
+		delete(additionalProperties, "trading")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_quote.go
+++ b/model_quote.go
@@ -13,7 +13,6 @@ package paxos
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -36,6 +35,7 @@ type Quote struct {
 	CreatedAt time.Time `json:"created_at"`
 	// The time at which the quote expires.
 	ExpiresAt time.Time `json:"expires_at"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Quote Quote
@@ -275,6 +275,11 @@ func (o Quote) ToMap() (map[string]interface{}, error) {
 	toSerialize["quote_asset"] = o.QuoteAsset
 	toSerialize["created_at"] = o.CreatedAt
 	toSerialize["expires_at"] = o.ExpiresAt
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -309,15 +314,27 @@ func (o *Quote) UnmarshalJSON(data []byte) (err error) {
 
 	varQuote := _Quote{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varQuote)
+	err = json.Unmarshal(data, &varQuote)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Quote(varQuote)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "side")
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "base_asset")
+		delete(additionalProperties, "quote_asset")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "expires_at")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_quote_execution.go
+++ b/model_quote_execution.go
@@ -13,7 +13,6 @@ package paxos
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -55,6 +54,7 @@ type QuoteExecution struct {
 	AccountId *string `json:"account_id,omitempty"`
 	// The ID of the profile under which to deposit the funds.
 	RecipientProfileId *string `json:"recipient_profile_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _QuoteExecution QuoteExecution
@@ -608,6 +608,11 @@ func (o QuoteExecution) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.RecipientProfileId) {
 		toSerialize["recipient_profile_id"] = o.RecipientProfileId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -646,15 +651,37 @@ func (o *QuoteExecution) UnmarshalJSON(data []byte) (err error) {
 
 	varQuoteExecution := _QuoteExecution{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varQuoteExecution)
+	err = json.Unmarshal(data, &varQuoteExecution)
 
 	if err != nil {
 		return err
 	}
 
 	*o = QuoteExecution(varQuoteExecution)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "quote_id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "side")
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "base_amount")
+		delete(additionalProperties, "base_asset")
+		delete(additionalProperties, "quote_amount")
+		delete(additionalProperties, "quote_asset")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "settled_at")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "recipient_profile_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_recent_execution.go
+++ b/model_recent_execution.go
@@ -27,7 +27,10 @@ type RecentExecution struct {
 	Amount *string `json:"amount,omitempty"`
 	// Execution timestamp.
 	ExecutedAt *string `json:"executed_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _RecentExecution RecentExecution
 
 // NewRecentExecution instantiates a new RecentExecution object
 // This constructor will assign default values to properties that have it defined,
@@ -196,7 +199,36 @@ func (o RecentExecution) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.ExecutedAt) {
 		toSerialize["executed_at"] = o.ExecutedAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *RecentExecution) UnmarshalJSON(data []byte) (err error) {
+	varRecentExecution := _RecentExecution{}
+
+	err = json.Unmarshal(data, &varRecentExecution)
+
+	if err != nil {
+		return err
+	}
+
+	*o = RecentExecution(varRecentExecution)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "match_number")
+		delete(additionalProperties, "price")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "executed_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableRecentExecution struct {

--- a/model_reject_crypto_deposit_request.go
+++ b/model_reject_crypto_deposit_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -23,6 +22,7 @@ var _ MappedNullable = &RejectCryptoDepositRequest{}
 type RejectCryptoDepositRequest struct {
 	// The Identity (`identity_id`) of the end user that requests to reject the deposit.
 	IdentityId string `json:"identity_id"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _RejectCryptoDepositRequest RejectCryptoDepositRequest
@@ -80,6 +80,11 @@ func (o RejectCryptoDepositRequest) MarshalJSON() ([]byte, error) {
 func (o RejectCryptoDepositRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["identity_id"] = o.IdentityId
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -107,15 +112,20 @@ func (o *RejectCryptoDepositRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varRejectCryptoDepositRequest := _RejectCryptoDepositRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varRejectCryptoDepositRequest)
+	err = json.Unmarshal(data, &varRejectCryptoDepositRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = RejectCryptoDepositRequest(varRejectCryptoDepositRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "identity_id")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_retry_id_verification_response.go
+++ b/model_retry_id_verification_response.go
@@ -21,7 +21,10 @@ var _ MappedNullable = &RetryIdVerificationResponse{}
 type RetryIdVerificationResponse struct {
 	// The id verification URL assigned to the retried identity.
 	Url *string `json:"url,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _RetryIdVerificationResponse RetryIdVerificationResponse
 
 // NewRetryIdVerificationResponse instantiates a new RetryIdVerificationResponse object
 // This constructor will assign default values to properties that have it defined,
@@ -85,7 +88,33 @@ func (o RetryIdVerificationResponse) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Url) {
 		toSerialize["url"] = o.Url
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *RetryIdVerificationResponse) UnmarshalJSON(data []byte) (err error) {
+	varRetryIdVerificationResponse := _RetryIdVerificationResponse{}
+
+	err = json.Unmarshal(data, &varRetryIdVerificationResponse)
+
+	if err != nil {
+		return err
+	}
+
+	*o = RetryIdVerificationResponse(varRetryIdVerificationResponse)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "url")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableRetryIdVerificationResponse struct {

--- a/model_sandbox_set_identity_status_request.go
+++ b/model_sandbox_set_identity_status_request.go
@@ -25,7 +25,10 @@ type SandboxSetIdentityStatusRequest struct {
 	AdminDisabled *SetDisable `json:"admin_disabled,omitempty"`
 	DocumentVerificationStatus *IdentityStatus `json:"document_verification_status,omitempty"`
 	AdditionalScreeningStatus *IdentityStatus `json:"additional_screening_status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SandboxSetIdentityStatusRequest SandboxSetIdentityStatusRequest
 
 // NewSandboxSetIdentityStatusRequest instantiates a new SandboxSetIdentityStatusRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -264,7 +267,38 @@ func (o SandboxSetIdentityStatusRequest) ToMap() (map[string]interface{}, error)
 	if !IsNil(o.AdditionalScreeningStatus) {
 		toSerialize["additional_screening_status"] = o.AdditionalScreeningStatus
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SandboxSetIdentityStatusRequest) UnmarshalJSON(data []byte) (err error) {
+	varSandboxSetIdentityStatusRequest := _SandboxSetIdentityStatusRequest{}
+
+	err = json.Unmarshal(data, &varSandboxSetIdentityStatusRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = SandboxSetIdentityStatusRequest(varSandboxSetIdentityStatusRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id_verification_status")
+		delete(additionalProperties, "sanctions_verification_status")
+		delete(additionalProperties, "user_disabled")
+		delete(additionalProperties, "admin_disabled")
+		delete(additionalProperties, "document_verification_status")
+		delete(additionalProperties, "additional_screening_status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSandboxSetIdentityStatusRequest struct {

--- a/model_secondary_status.go
+++ b/model_secondary_status.go
@@ -22,7 +22,10 @@ type SecondaryStatus struct {
 	Name *SecondaryStatusName `json:"name,omitempty"`
 	// Additional information about the current status of the transfer (e.g. if information is missing).
 	Detail *string `json:"detail,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SecondaryStatus SecondaryStatus
 
 // NewSecondaryStatus instantiates a new SecondaryStatus object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o SecondaryStatus) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Detail) {
 		toSerialize["detail"] = o.Detail
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SecondaryStatus) UnmarshalJSON(data []byte) (err error) {
+	varSecondaryStatus := _SecondaryStatus{}
+
+	err = json.Unmarshal(data, &varSecondaryStatus)
+
+	if err != nil {
+		return err
+	}
+
+	*o = SecondaryStatus(varSecondaryStatus)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "name")
+		delete(additionalProperties, "detail")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSecondaryStatus struct {

--- a/model_set_disable.go
+++ b/model_set_disable.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &SetDisable{}
 // SetDisable struct for SetDisable
 type SetDisable struct {
 	Disabled *bool `json:"disabled,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _SetDisable SetDisable
 
 // NewSetDisable instantiates a new SetDisable object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o SetDisable) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Disabled) {
 		toSerialize["disabled"] = o.Disabled
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *SetDisable) UnmarshalJSON(data []byte) (err error) {
+	varSetDisable := _SetDisable{}
+
+	err = json.Unmarshal(data, &varSetDisable)
+
+	if err != nil {
+		return err
+	}
+
+	*o = SetDisable(varSetDisable)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "disabled")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableSetDisable struct {

--- a/model_set_verifier_credentials_request.go
+++ b/model_set_verifier_credentials_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type SetVerifierCredentialsRequest struct {
 	VerifierType IdentityprotoVerifierType `json:"verifier_type"`
 	AuthToken *string `json:"auth_token,omitempty"`
 	AuthSecret *string `json:"auth_secret,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _SetVerifierCredentialsRequest SetVerifierCredentialsRequest
@@ -151,6 +151,11 @@ func (o SetVerifierCredentialsRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.AuthSecret) {
 		toSerialize["auth_secret"] = o.AuthSecret
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -178,15 +183,22 @@ func (o *SetVerifierCredentialsRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varSetVerifierCredentialsRequest := _SetVerifierCredentialsRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varSetVerifierCredentialsRequest)
+	err = json.Unmarshal(data, &varSetVerifierCredentialsRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = SetVerifierCredentialsRequest(varSetVerifierCredentialsRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "verifier_type")
+		delete(additionalProperties, "auth_token")
+		delete(additionalProperties, "auth_secret")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_stablecoin_conversion.go
+++ b/model_stablecoin_conversion.go
@@ -50,7 +50,10 @@ type StablecoinConversion struct {
 	Metadata *map[string]string `json:"metadata,omitempty"`
 	// For directed settlement, the receiving side `profile_id`.
 	RecipientProfileId *string `json:"recipient_profile_id,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _StablecoinConversion StablecoinConversion
 
 // NewStablecoinConversion instantiates a new StablecoinConversion object
 // This constructor will assign default values to properties that have it defined,
@@ -604,7 +607,47 @@ func (o StablecoinConversion) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.RecipientProfileId) {
 		toSerialize["recipient_profile_id"] = o.RecipientProfileId
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *StablecoinConversion) UnmarshalJSON(data []byte) (err error) {
+	varStablecoinConversion := _StablecoinConversion{}
+
+	err = json.Unmarshal(data, &varStablecoinConversion)
+
+	if err != nil {
+		return err
+	}
+
+	*o = StablecoinConversion(varStablecoinConversion)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "source_asset")
+		delete(additionalProperties, "target_asset")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "settled_at")
+		delete(additionalProperties, "cancelled_at")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "recipient_profile_id")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableStablecoinConversion struct {

--- a/model_tax_detail.go
+++ b/model_tax_detail.go
@@ -22,7 +22,10 @@ type TaxDetail struct {
 	TaxPayerId *string `json:"tax_payer_id,omitempty" validate:"regexp=^[0-9A-Za-z \\/?:().,&'+-]+$"`
 	TaxPayerCountry *string `json:"tax_payer_country,omitempty"`
 	TinVerificationStatus *TINVerificationStatus `json:"tin_verification_status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TaxDetail TaxDetail
 
 // NewTaxDetail instantiates a new TaxDetail object
 // This constructor will assign default values to properties that have it defined,
@@ -156,7 +159,35 @@ func (o TaxDetail) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.TinVerificationStatus) {
 		toSerialize["tin_verification_status"] = o.TinVerificationStatus
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TaxDetail) UnmarshalJSON(data []byte) (err error) {
+	varTaxDetail := _TaxDetail{}
+
+	err = json.Unmarshal(data, &varTaxDetail)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TaxDetail(varTaxDetail)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "tax_payer_id")
+		delete(additionalProperties, "tax_payer_country")
+		delete(additionalProperties, "tin_verification_status")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTaxDetail struct {

--- a/model_tax_form_url.go
+++ b/model_tax_form_url.go
@@ -24,7 +24,10 @@ type TaxFormURL struct {
 	TaxYear *string `json:"tax_year,omitempty"`
 	Revision *string `json:"revision,omitempty"`
 	Url *string `json:"url,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TaxFormURL TaxFormURL
 
 // NewTaxFormURL instantiates a new TaxFormURL object
 // This constructor will assign default values to properties that have it defined,
@@ -228,7 +231,37 @@ func (o TaxFormURL) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Url) {
 		toSerialize["url"] = o.Url
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TaxFormURL) UnmarshalJSON(data []byte) (err error) {
+	varTaxFormURL := _TaxFormURL{}
+
+	err = json.Unmarshal(data, &varTaxFormURL)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TaxFormURL(varTaxFormURL)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "tax_year")
+		delete(additionalProperties, "revision")
+		delete(additionalProperties, "url")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTaxFormURL struct {

--- a/model_ticker_record.go
+++ b/model_ticker_record.go
@@ -28,7 +28,10 @@ type TickerRecord struct {
 	Today *ExchangeStats `json:"today,omitempty"`
 	// The time at which this data was retrieved.
 	SnapshotAt *time.Time `json:"snapshot_at,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TickerRecord TickerRecord
 
 // NewTickerRecord instantiates a new TickerRecord object
 // This constructor will assign default values to properties that have it defined,
@@ -302,7 +305,39 @@ func (o TickerRecord) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SnapshotAt) {
 		toSerialize["snapshot_at"] = o.SnapshotAt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TickerRecord) UnmarshalJSON(data []byte) (err error) {
+	varTickerRecord := _TickerRecord{}
+
+	err = json.Unmarshal(data, &varTickerRecord)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TickerRecord(varTickerRecord)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "market")
+		delete(additionalProperties, "best_bid")
+		delete(additionalProperties, "best_ask")
+		delete(additionalProperties, "last_execution")
+		delete(additionalProperties, "last_day")
+		delete(additionalProperties, "today")
+		delete(additionalProperties, "snapshot_at")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTickerRecord struct {

--- a/model_timestamp_filter.go
+++ b/model_timestamp_filter.go
@@ -30,7 +30,10 @@ type TimestampFilter struct {
 	Gte *time.Time `json:"gte,omitempty"`
 	// Include timestamps strictly greater than gt. RFC3339 format, like `2006-01-02T15:04:05Z`.
 	Gt *time.Time `json:"gt,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TimestampFilter TimestampFilter
 
 // NewTimestampFilter instantiates a new TimestampFilter object
 // This constructor will assign default values to properties that have it defined,
@@ -234,7 +237,37 @@ func (o TimestampFilter) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Gt) {
 		toSerialize["gt"] = o.Gt
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TimestampFilter) UnmarshalJSON(data []byte) (err error) {
+	varTimestampFilter := _TimestampFilter{}
+
+	err = json.Unmarshal(data, &varTimestampFilter)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TimestampFilter(varTimestampFilter)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "lt")
+		delete(additionalProperties, "lte")
+		delete(additionalProperties, "eq")
+		delete(additionalProperties, "gte")
+		delete(additionalProperties, "gt")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTimestampFilter struct {

--- a/model_timestamp_range.go
+++ b/model_timestamp_range.go
@@ -24,7 +24,10 @@ type TimestampRange struct {
 	Begin *time.Time `json:"begin,omitempty"`
 	// Only return records before this timestamp, inclusive. RFC3339 format, like `2006-01-02T15:04:05Z`.
 	End *time.Time `json:"end,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TimestampRange TimestampRange
 
 // NewTimestampRange instantiates a new TimestampRange object
 // This constructor will assign default values to properties that have it defined,
@@ -123,7 +126,34 @@ func (o TimestampRange) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.End) {
 		toSerialize["end"] = o.End
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TimestampRange) UnmarshalJSON(data []byte) (err error) {
+	varTimestampRange := _TimestampRange{}
+
+	err = json.Unmarshal(data, &varTimestampRange)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TimestampRange(varTimestampRange)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "begin")
+		delete(additionalProperties, "end")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTimestampRange struct {

--- a/model_transfer.go
+++ b/model_transfer.go
@@ -13,7 +13,6 @@ package paxos
 import (
 	"encoding/json"
 	"time"
-	"bytes"
 	"fmt"
 )
 
@@ -66,6 +65,7 @@ type Transfer struct {
 	// For fiat withdrawals, the Paxos ID of the owner's fiat account (UUID).
 	FiatAccountId *string `json:"fiat_account_id,omitempty"`
 	SecondaryStatus *SecondaryStatus `json:"secondary_status,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _Transfer Transfer
@@ -864,6 +864,11 @@ func (o Transfer) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SecondaryStatus) {
 		toSerialize["secondary_status"] = o.SecondaryStatus
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -902,15 +907,44 @@ func (o *Transfer) UnmarshalJSON(data []byte) (err error) {
 
 	varTransfer := _Transfer{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varTransfer)
+	err = json.Unmarshal(data, &varTransfer)
 
 	if err != nil {
 		return err
 	}
 
 	*o = Transfer(varTransfer)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "customer_id")
+		delete(additionalProperties, "profile_id")
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "amount")
+		delete(additionalProperties, "total")
+		delete(additionalProperties, "fee")
+		delete(additionalProperties, "asset")
+		delete(additionalProperties, "balance_asset")
+		delete(additionalProperties, "direction")
+		delete(additionalProperties, "type")
+		delete(additionalProperties, "status")
+		delete(additionalProperties, "created_at")
+		delete(additionalProperties, "updated_at")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "destination_address")
+		delete(additionalProperties, "crypto_network")
+		delete(additionalProperties, "crypto_tx_hash")
+		delete(additionalProperties, "crypto_tx_index")
+		delete(additionalProperties, "account_id")
+		delete(additionalProperties, "auto_conversion")
+		delete(additionalProperties, "group_id")
+		delete(additionalProperties, "fiat_account_id")
+		delete(additionalProperties, "secondary_status")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_transfer_limit.go
+++ b/model_transfer_limit.go
@@ -33,7 +33,10 @@ type TransferLimit struct {
 	Remaining *string `json:"remaining,omitempty"`
 	// The asset that limit and remaining are given in, e.g. \"USD\", \"BTC\", \"ETH\".
 	LimitAsset *string `json:"limit_asset,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _TransferLimit TransferLimit
 
 // NewTransferLimit instantiates a new TransferLimit object
 // This constructor will assign default values to properties that have it defined,
@@ -307,7 +310,39 @@ func (o TransferLimit) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LimitAsset) {
 		toSerialize["limit_asset"] = o.LimitAsset
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *TransferLimit) UnmarshalJSON(data []byte) (err error) {
+	varTransferLimit := _TransferLimit{}
+
+	err = json.Unmarshal(data, &varTransferLimit)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TransferLimit(varTransferLimit)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "id")
+		delete(additionalProperties, "rule_id")
+		delete(additionalProperties, "transfer_types")
+		delete(additionalProperties, "period_seconds")
+		delete(additionalProperties, "limit")
+		delete(additionalProperties, "remaining")
+		delete(additionalProperties, "limit_asset")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableTransferLimit struct {

--- a/model_update_account_request.go
+++ b/model_update_account_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UpdateAccountRequest struct {
 	Account Account `json:"account"`
 	// true if the account is required to be disabled by the API user.
 	SetUserDisabled *bool `json:"set_user_disabled,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateAccountRequest UpdateAccountRequest
@@ -116,6 +116,11 @@ func (o UpdateAccountRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.SetUserDisabled) {
 		toSerialize["set_user_disabled"] = o.SetUserDisabled
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -143,15 +148,21 @@ func (o *UpdateAccountRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateAccountRequest := _UpdateAccountRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateAccountRequest)
+	err = json.Unmarshal(data, &varUpdateAccountRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateAccountRequest(varUpdateAccountRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "account")
+		delete(additionalProperties, "set_user_disabled")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_update_crypto_deposit_request.go
+++ b/model_update_crypto_deposit_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -24,6 +23,7 @@ type UpdateCryptoDepositRequest struct {
 	// The Identity (`identity_id`) of the end user updating the deposit.
 	IdentityId string `json:"identity_id"`
 	OriginatorAddressInfo AddressInfo `json:"originator_address_info"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateCryptoDepositRequest UpdateCryptoDepositRequest
@@ -107,6 +107,11 @@ func (o UpdateCryptoDepositRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["identity_id"] = o.IdentityId
 	toSerialize["originator_address_info"] = o.OriginatorAddressInfo
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -135,15 +140,21 @@ func (o *UpdateCryptoDepositRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateCryptoDepositRequest := _UpdateCryptoDepositRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateCryptoDepositRequest)
+	err = json.Unmarshal(data, &varUpdateCryptoDepositRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateCryptoDepositRequest(varUpdateCryptoDepositRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "identity_id")
+		delete(additionalProperties, "originator_address_info")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_update_fiat_account_request.go
+++ b/model_update_fiat_account_request.go
@@ -23,7 +23,10 @@ type UpdateFiatAccountRequest struct {
 	FiatNetworkInstructions *UpdateFiatAccountRequestUpdateFiatNetworkInstructions `json:"fiat_network_instructions,omitempty"`
 	// Optional client-specified metadata. Up to 6 key/value pairs may be provided. Each key and value must be less than or equal to 100 characters.
 	Metadata *map[string]string `json:"metadata,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UpdateFiatAccountRequest UpdateFiatAccountRequest
 
 // NewUpdateFiatAccountRequest instantiates a new UpdateFiatAccountRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -157,7 +160,35 @@ func (o UpdateFiatAccountRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Metadata) {
 		toSerialize["metadata"] = o.Metadata
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UpdateFiatAccountRequest) UnmarshalJSON(data []byte) (err error) {
+	varUpdateFiatAccountRequest := _UpdateFiatAccountRequest{}
+
+	err = json.Unmarshal(data, &varUpdateFiatAccountRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = UpdateFiatAccountRequest(varUpdateFiatAccountRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "fiat_account_owner")
+		delete(additionalProperties, "fiat_network_instructions")
+		delete(additionalProperties, "metadata")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUpdateFiatAccountRequest struct {

--- a/model_update_fiat_account_request_update_fiat_network_instructions.go
+++ b/model_update_fiat_account_request_update_fiat_network_instructions.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &UpdateFiatAccountRequestUpdateFiatNetworkInstructions{}
 // UpdateFiatAccountRequestUpdateFiatNetworkInstructions struct for UpdateFiatAccountRequestUpdateFiatNetworkInstructions
 type UpdateFiatAccountRequestUpdateFiatNetworkInstructions struct {
 	Wire *UpdateFiatNetworkInstructionsUpdateWire `json:"wire,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UpdateFiatAccountRequestUpdateFiatNetworkInstructions UpdateFiatAccountRequestUpdateFiatNetworkInstructions
 
 // NewUpdateFiatAccountRequestUpdateFiatNetworkInstructions instantiates a new UpdateFiatAccountRequestUpdateFiatNetworkInstructions object
 // This constructor will assign default values to properties that have it defined,
@@ -84,7 +87,33 @@ func (o UpdateFiatAccountRequestUpdateFiatNetworkInstructions) ToMap() (map[stri
 	if !IsNil(o.Wire) {
 		toSerialize["wire"] = o.Wire
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UpdateFiatAccountRequestUpdateFiatNetworkInstructions) UnmarshalJSON(data []byte) (err error) {
+	varUpdateFiatAccountRequestUpdateFiatNetworkInstructions := _UpdateFiatAccountRequestUpdateFiatNetworkInstructions{}
+
+	err = json.Unmarshal(data, &varUpdateFiatAccountRequestUpdateFiatNetworkInstructions)
+
+	if err != nil {
+		return err
+	}
+
+	*o = UpdateFiatAccountRequestUpdateFiatNetworkInstructions(varUpdateFiatAccountRequestUpdateFiatNetworkInstructions)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "wire")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUpdateFiatAccountRequestUpdateFiatNetworkInstructions struct {

--- a/model_update_fiat_network_instructions_update_wire.go
+++ b/model_update_fiat_network_instructions_update_wire.go
@@ -22,7 +22,10 @@ type UpdateFiatNetworkInstructionsUpdateWire struct {
 	FiatAccountOwnerAddress *MailingAddress `json:"fiat_account_owner_address,omitempty"`
 	RoutingDetails *UpdateWireUpdateRoutingDetails `json:"routing_details,omitempty"`
 	IntermediaryRoutingDetails *UpdateWireUpdateRoutingDetails `json:"intermediary_routing_details,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UpdateFiatNetworkInstructionsUpdateWire UpdateFiatNetworkInstructionsUpdateWire
 
 // NewUpdateFiatNetworkInstructionsUpdateWire instantiates a new UpdateFiatNetworkInstructionsUpdateWire object
 // This constructor will assign default values to properties that have it defined,
@@ -156,7 +159,35 @@ func (o UpdateFiatNetworkInstructionsUpdateWire) ToMap() (map[string]interface{}
 	if !IsNil(o.IntermediaryRoutingDetails) {
 		toSerialize["intermediary_routing_details"] = o.IntermediaryRoutingDetails
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UpdateFiatNetworkInstructionsUpdateWire) UnmarshalJSON(data []byte) (err error) {
+	varUpdateFiatNetworkInstructionsUpdateWire := _UpdateFiatNetworkInstructionsUpdateWire{}
+
+	err = json.Unmarshal(data, &varUpdateFiatNetworkInstructionsUpdateWire)
+
+	if err != nil {
+		return err
+	}
+
+	*o = UpdateFiatNetworkInstructionsUpdateWire(varUpdateFiatNetworkInstructionsUpdateWire)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "fiat_account_owner_address")
+		delete(additionalProperties, "routing_details")
+		delete(additionalProperties, "intermediary_routing_details")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUpdateFiatNetworkInstructionsUpdateWire struct {

--- a/model_update_identity_request.go
+++ b/model_update_identity_request.go
@@ -35,7 +35,10 @@ type UpdateIdentityRequest struct {
 	IsMerchant *bool `json:"is_merchant,omitempty"`
 	// Set to the timestamp the identity has last undergone a periodic kyc refresh. If unset, the update is not for periodic kyc refresh.
 	LastKycRefreshDate *time.Time `json:"last_kyc_refresh_date,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UpdateIdentityRequest UpdateIdentityRequest
 
 // NewUpdateIdentityRequest instantiates a new UpdateIdentityRequest object
 // This constructor will assign default values to properties that have it defined,
@@ -414,7 +417,42 @@ func (o UpdateIdentityRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.LastKycRefreshDate) {
 		toSerialize["last_kyc_refresh_date"] = o.LastKycRefreshDate
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UpdateIdentityRequest) UnmarshalJSON(data []byte) (err error) {
+	varUpdateIdentityRequest := _UpdateIdentityRequest{}
+
+	err = json.Unmarshal(data, &varUpdateIdentityRequest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = UpdateIdentityRequest(varUpdateIdentityRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "person_details")
+		delete(additionalProperties, "metadata")
+		delete(additionalProperties, "set_user_disabled")
+		delete(additionalProperties, "institution_details")
+		delete(additionalProperties, "ref_id")
+		delete(additionalProperties, "tax_details")
+		delete(additionalProperties, "set_tax_details_not_required")
+		delete(additionalProperties, "customer_due_diligence")
+		delete(additionalProperties, "is_merchant")
+		delete(additionalProperties, "last_kyc_refresh_date")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUpdateIdentityRequest struct {

--- a/model_update_profile_request.go
+++ b/model_update_profile_request.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -22,6 +21,7 @@ var _ MappedNullable = &UpdateProfileRequest{}
 // UpdateProfileRequest struct for UpdateProfileRequest
 type UpdateProfileRequest struct {
 	Nickname string `json:"nickname"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _UpdateProfileRequest UpdateProfileRequest
@@ -79,6 +79,11 @@ func (o UpdateProfileRequest) MarshalJSON() ([]byte, error) {
 func (o UpdateProfileRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["nickname"] = o.Nickname
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -106,15 +111,20 @@ func (o *UpdateProfileRequest) UnmarshalJSON(data []byte) (err error) {
 
 	varUpdateProfileRequest := _UpdateProfileRequest{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varUpdateProfileRequest)
+	err = json.Unmarshal(data, &varUpdateProfileRequest)
 
 	if err != nil {
 		return err
 	}
 
 	*o = UpdateProfileRequest(varUpdateProfileRequest)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "nickname")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }

--- a/model_update_wire_update_routing_details.go
+++ b/model_update_wire_update_routing_details.go
@@ -22,7 +22,10 @@ type UpdateWireUpdateRoutingDetails struct {
 	// The name of the bank.
 	BankName *string `json:"bank_name,omitempty"`
 	BankAddress *MailingAddress `json:"bank_address,omitempty"`
+	AdditionalProperties map[string]interface{}
 }
+
+type _UpdateWireUpdateRoutingDetails UpdateWireUpdateRoutingDetails
 
 // NewUpdateWireUpdateRoutingDetails instantiates a new UpdateWireUpdateRoutingDetails object
 // This constructor will assign default values to properties that have it defined,
@@ -121,7 +124,34 @@ func (o UpdateWireUpdateRoutingDetails) ToMap() (map[string]interface{}, error) 
 	if !IsNil(o.BankAddress) {
 		toSerialize["bank_address"] = o.BankAddress
 	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
+}
+
+func (o *UpdateWireUpdateRoutingDetails) UnmarshalJSON(data []byte) (err error) {
+	varUpdateWireUpdateRoutingDetails := _UpdateWireUpdateRoutingDetails{}
+
+	err = json.Unmarshal(data, &varUpdateWireUpdateRoutingDetails)
+
+	if err != nil {
+		return err
+	}
+
+	*o = UpdateWireUpdateRoutingDetails(varUpdateWireUpdateRoutingDetails)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "bank_name")
+		delete(additionalProperties, "bank_address")
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
 }
 
 type NullableUpdateWireUpdateRoutingDetails struct {

--- a/model_wire_routing_details.go
+++ b/model_wire_routing_details.go
@@ -12,7 +12,6 @@ package paxos
 
 import (
 	"encoding/json"
-	"bytes"
 	"fmt"
 )
 
@@ -27,6 +26,7 @@ type WireRoutingDetails struct {
 	// The name of the bank.
 	BankName string `json:"bank_name"`
 	BankAddress MailingAddress `json:"bank_address"`
+	AdditionalProperties map[string]interface{}
 }
 
 type _WireRoutingDetails WireRoutingDetails
@@ -162,6 +162,11 @@ func (o WireRoutingDetails) ToMap() (map[string]interface{}, error) {
 	toSerialize["routing_number"] = o.RoutingNumber
 	toSerialize["bank_name"] = o.BankName
 	toSerialize["bank_address"] = o.BankAddress
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
 	return toSerialize, nil
 }
 
@@ -192,15 +197,23 @@ func (o *WireRoutingDetails) UnmarshalJSON(data []byte) (err error) {
 
 	varWireRoutingDetails := _WireRoutingDetails{}
 
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	err = decoder.Decode(&varWireRoutingDetails)
+	err = json.Unmarshal(data, &varWireRoutingDetails)
 
 	if err != nil {
 		return err
 	}
 
 	*o = WireRoutingDetails(varWireRoutingDetails)
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "routing_number_type")
+		delete(additionalProperties, "routing_number")
+		delete(additionalProperties, "bank_name")
+		delete(additionalProperties, "bank_address")
+		o.AdditionalProperties = additionalProperties
+	}
 
 	return err
 }


### PR DESCRIPTION
Regenerate the Paxos SDK removing the following lines: 
```
	decoder := json.NewDecoder(bytes.NewReader(data))
	decoder.DisallowUnknownFields()
	err = decoder.Decode(&varBeneficiaryInstitution)
```